### PR TITLE
Add i18n: extract UI text to JSON, add language toggle (EN/UK/HR/DE)

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -13,6 +13,7 @@ import {
   FolderTree,
   Logs,
   Menu,
+  Languages,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -22,6 +23,13 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import Dashboard from "@/components/pages/dashboard";
 import Products from "@/components/pages/products";
 import UsersPage from "@/components/pages/users";
@@ -29,6 +37,14 @@ import LocationsPage from "@/components/pages/locations";
 import LogsPage from "@/components/pages/logs";
 import { Permission, PERMISSIONS } from "@/lib/permissions";
 import type { SafeUser } from "@/lib/userTypes";
+import {
+  useLanguage,
+  translateRank,
+  translateClearance,
+  LOCALES,
+  type Locale,
+  type Translate,
+} from "@/lib/i18n";
 
 type Page = "dashboard" | "products" | "users" | "locations" | "logs";
 
@@ -38,6 +54,13 @@ interface NavItem {
   icon: React.ComponentType<{ className?: string }>;
 }
 
+const LANGUAGE_NAMES: Record<Locale, string> = {
+  en: "English",
+  uk: "Українська",
+  hr: "Hrvatski",
+  de: "Deutsch",
+};
+
 interface SidebarContentProps {
   navItems: NavItem[];
   currentPage: Page;
@@ -46,6 +69,9 @@ interface SidebarContentProps {
   dark: boolean;
   onToggleDark: () => void;
   onLogout: () => void;
+  t: Translate;
+  language: Locale;
+  onLanguageChange: (locale: Locale) => void;
 }
 
 function SidebarContent({
@@ -56,6 +82,9 @@ function SidebarContent({
   dark,
   onToggleDark,
   onLogout,
+  t,
+  language,
+  onLanguageChange,
 }: SidebarContentProps) {
   return (
     <div className="flex h-full flex-col bg-sidebar">
@@ -67,7 +96,7 @@ function SidebarContent({
             height="24"
             viewBox="0 0 24 24"
             fill="none"
-            aria-label="StockPulse logo"
+            aria-label={t("appShell.logoAlt")}
           >
             <rect
               x="2"
@@ -117,7 +146,7 @@ function SidebarContent({
                   ? "bg-sidebar-accent text-sidebar-foreground"
                   : "text-muted-foreground hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
               }`}
-              data-testid={`link-${label.toLowerCase()}`}
+              data-testid={`link-${page}`}
             >
               <Icon className="h-4 w-4 shrink-0" />
               <span className="truncate">{label}</span>
@@ -143,7 +172,7 @@ function SidebarContent({
                   {user.callsign ? user.callsign : user.full_name}
                 </p>
                 <p className="truncate text-[10px] text-muted-foreground">
-                  {user.rank}
+                  {translateRank(t, user.rank)}
                 </p>
               </div>
             </div>
@@ -152,12 +181,34 @@ function SidebarContent({
               variant="outline"
               className="h-5 px-1.5 py-0 text-[10px] font-normal"
             >
-              {user.clearance_level}
+              {translateClearance(t, user.clearance_level)}
             </Badge>
           </div>
         )}
 
         <div className="space-y-1.5 px-3 pb-5">
+          <div className="flex h-9 items-center gap-2 px-3">
+            <Languages className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Select
+              value={language}
+              onValueChange={(value) => onLanguageChange(value as Locale)}
+            >
+              <SelectTrigger
+                className="h-9 flex-1 border-none bg-transparent px-0 text-xs shadow-none focus:ring-0"
+                data-testid="select-language"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LOCALES.map((locale) => (
+                  <SelectItem key={locale} value={locale}>
+                    {LANGUAGE_NAMES[locale]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
           <Button
             variant="ghost"
             size="sm"
@@ -170,7 +221,7 @@ function SidebarContent({
             ) : (
               <Moon className="h-3.5 w-3.5" />
             )}
-            {dark ? "Light theme" : "Dark theme"}
+            {dark ? t("appShell.lightTheme") : t("appShell.darkTheme")}
           </Button>
 
           <Button
@@ -181,7 +232,7 @@ function SidebarContent({
             data-testid="button-logout"
           >
             <LogOut className="h-3.5 w-3.5" />
-            Logout
+            {t("appShell.logout")}
           </Button>
         </div>
       </div>
@@ -191,6 +242,7 @@ function SidebarContent({
 
 export default function AppShell() {
   const { user, logout } = useAuth();
+  const { t, language, setLanguage } = useLanguage();
   const [currentPage, setCurrentPage] = useState<Page>("dashboard");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [dark, setDark] = useState(
@@ -207,22 +259,22 @@ export default function AppShell() {
     user?.permissions?.includes(permission) ?? false;
 
   const navItems = [
-    { page: "dashboard" as Page, label: "Dashboard", icon: LayoutDashboard },
+    { page: "dashboard" as Page, label: t("nav.dashboard"), icon: LayoutDashboard },
 
     ...(hasPermission(PERMISSIONS.READ_PRODUCTS)
-      ? [{ page: "products" as Page, label: "Products", icon: Package }]
+      ? [{ page: "products" as Page, label: t("nav.products"), icon: Package }]
       : []),
 
     ...(hasPermission(PERMISSIONS.READ_LOCATIONS)
-      ? [{ page: "locations" as Page, label: "Locations", icon: FolderTree }]
+      ? [{ page: "locations" as Page, label: t("nav.locations"), icon: FolderTree }]
       : []),
 
     ...(hasPermission(PERMISSIONS.READ_USERS)
-      ? [{ page: "users" as Page, label: "Users", icon: Users }]
+      ? [{ page: "users" as Page, label: t("nav.users"), icon: Users }]
       : []),
 
     ...(hasPermission(PERMISSIONS.READ_LOGS)
-      ? [{ page: "logs" as Page, label: "Audit Logs", icon: Logs }]
+      ? [{ page: "logs" as Page, label: t("nav.auditLogs"), icon: Logs }]
       : []),
   ];
 
@@ -275,6 +327,9 @@ export default function AppShell() {
       setSidebarOpen(false);
       logout();
     },
+    t,
+    language,
+    onLanguageChange: setLanguage,
   };
 
   return (
@@ -294,7 +349,7 @@ export default function AppShell() {
       <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
         <SheetContent side="left" className="w-[280px] p-0 sm:w-[320px]">
           <SheetHeader className="sr-only">
-            <SheetTitle>Navigation menu</SheetTitle>
+            <SheetTitle>{t("appShell.navMenuTitle")}</SheetTitle>
           </SheetHeader>
           <SidebarContent {...sidebarProps} />
         </SheetContent>
@@ -310,7 +365,7 @@ export default function AppShell() {
               size="icon"
               className="h-9 w-9"
               onClick={() => setSidebarOpen(true)}
-              aria-label="Open navigation menu"
+              aria-label={t("appShell.openNavMenu")}
             >
               <Menu className="h-5 w-5" />
             </Button>
@@ -358,7 +413,9 @@ export default function AppShell() {
           </div>
 
           <Badge variant="outline" className="max-w-[120px] truncate text-[10px]">
-            {user?.clearance_level ?? "User"}
+            {user?.clearance_level
+              ? translateClearance(t, user.clearance_level)
+              : t("appShell.defaultUserBadge")}
           </Badge>
         </header>
 

--- a/src/components/pages/dashboard.tsx
+++ b/src/components/pages/dashboard.tsx
@@ -12,6 +12,7 @@ import {
 import type { Product } from "@/lib/schema";
 import { Badge } from "@/components/ui/badge";
 import { getErrorMessage } from "@/lib/apiClientError";
+import { useLanguage } from "@/lib/i18n";
 
 interface Stats {
   totalProducts: number;
@@ -29,6 +30,8 @@ export default function Dashboard({
     page: "dashboard" | "products" | "users" | "locations",
   ) => void;
 }) {
+  const { t } = useLanguage();
+
   const {
     data: stats,
     isLoading: statsLoading,
@@ -56,7 +59,7 @@ export default function Dashboard({
   const statItems = [
     {
       key: "products",
-      label: "Total Products",
+      label: t("dashboard.totalProducts"),
       value: statsLoading ? "—" : (stats?.totalProducts ?? 0),
       icon: Package,
       iconClass: "text-primary",
@@ -66,7 +69,7 @@ export default function Dashboard({
     },
     {
       key: "value",
-      label: "Total Value",
+      label: t("dashboard.totalValue"),
       value: statsLoading
         ? "—"
         : `$${(stats?.totalValue ?? 0).toLocaleString("en-US", {
@@ -80,7 +83,7 @@ export default function Dashboard({
     },
     {
       key: "low-stock",
-      label: "Low Stock",
+      label: t("dashboard.lowStock"),
       value: statsLoading ? "—" : (stats?.lowStockCount ?? 0),
       icon: AlertTriangle,
       iconClass: "text-amber-600 dark:text-amber-400",
@@ -90,7 +93,7 @@ export default function Dashboard({
     },
     {
       key: "out-of-stock",
-      label: "Out of Stock",
+      label: t("dashboard.outOfStock"),
       value: statsLoading ? "—" : (stats?.outOfStockCount ?? 0),
       icon: XCircle,
       iconClass: "text-red-600 dark:text-red-400",
@@ -100,7 +103,7 @@ export default function Dashboard({
     },
     {
       key: "categories",
-      label: "Categories",
+      label: t("dashboard.categories"),
       value: statsLoading ? "—" : (stats?.categoriesCount ?? 0),
       icon: FolderOpen,
       iconClass: "text-violet-600 dark:text-violet-400",
@@ -117,7 +120,7 @@ export default function Dashboard({
             className="text-xl font-semibold tracking-tight sm:text-2xl"
             data-testid="text-page-title"
           >
-            Dashboard
+            {t("dashboard.title")}
           </h1>
         </div>
         <Card>
@@ -125,7 +128,7 @@ export default function Dashboard({
             <div className="text-sm text-destructive">
               {getErrorMessage(
                 statsErrorObj ?? productsErrorObj,
-                "Failed to load dashboard data",
+                t("dashboard.loadError"),
               )}
             </div>
           </CardContent>
@@ -141,10 +144,10 @@ export default function Dashboard({
           className="text-xl font-semibold tracking-tight sm:text-2xl"
           data-testid="text-page-title"
         >
-          Dashboard
+          {t("dashboard.title")}
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Overview of your inventory status
+          {t("dashboard.subtitle")}
         </p>
       </div>
 
@@ -252,14 +255,14 @@ export default function Dashboard({
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base font-medium">
               <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-              Low Stock Alerts
+              {t("dashboard.lowStockAlerts")}
             </CardTitle>
           </CardHeader>
 
           <CardContent>
             {lowStockProducts.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">
-                All products are well-stocked
+                {t("dashboard.allWellStocked")}
               </p>
             ) : (
               <div className="space-y-3">
@@ -282,7 +285,7 @@ export default function Dashboard({
                       variant="outline"
                       className="shrink-0 border-amber-300 text-xs text-amber-600 dark:border-amber-700 dark:text-amber-400"
                     >
-                      {product.quantity} left
+                      {t("dashboard.leftSuffix", { qty: product.quantity })}
                     </Badge>
                   </div>
                 ))}
@@ -295,14 +298,14 @@ export default function Dashboard({
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-base font-medium">
               <XCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
-              Out of Stock
+              {t("dashboard.outOfStock")}
             </CardTitle>
           </CardHeader>
 
           <CardContent>
             {outOfStockProducts.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">
-                No products are out of stock
+                {t("dashboard.noProductsOutOfStock")}
               </p>
             ) : (
               <div className="space-y-3">
@@ -322,7 +325,7 @@ export default function Dashboard({
                     </div>
 
                     <Badge variant="destructive" className="shrink-0 text-xs">
-                      Out of stock
+                      {t("dashboard.outOfStockBadge")}
                     </Badge>
                   </div>
                 ))}

--- a/src/components/pages/location-add-dialog.tsx
+++ b/src/components/pages/location-add-dialog.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import type { UseFormReturn } from "react-hook-form";
 import type { InsertProductLocation } from "@/lib/schema";
 import { LocationSearch } from "./location-search";
+import { useLanguage } from "@/lib/i18n";
 
 interface AddLocationDialogProps {
   open: boolean;
@@ -35,11 +36,13 @@ export function AddLocationDialog({
   usedLocationIds,
   isPending,
 }: AddLocationDialogProps) {
+  const { t } = useLanguage();
+
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add location</DialogTitle>
+          <DialogTitle>{t("locationForm.addLocation")}</DialogTitle>
         </DialogHeader>
 
         <Form {...form}>
@@ -49,7 +52,7 @@ export function AddLocationDialog({
               name="location_id"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Location</FormLabel>
+                  <FormLabel>{t("locationAddDialog.locationLabel")}</FormLabel>
                   <FormControl>
                     <LocationSearch
                       value={field.value}
@@ -67,7 +70,7 @@ export function AddLocationDialog({
               name="quantity"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Quantity</FormLabel>
+                  <FormLabel>{t("fields.quantity")}</FormLabel>
                   <FormControl>
                     <Input
                       type="number"
@@ -88,10 +91,10 @@ export function AddLocationDialog({
                 disabled={isPending}
                 data-testid="button-submit-location"
               >
-                {isPending ? "Adding..." : "Add"}
+                {isPending ? t("common.adding") : t("common.add")}
               </Button>
               <Button type="button" variant="ghost" onClick={onClose}>
-                Cancel
+                {t("common.cancel")}
               </Button>
             </div>
           </form>

--- a/src/components/pages/location-allocation-banner.tsx
+++ b/src/components/pages/location-allocation-banner.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { AlertTriangle, CheckCircle2, XCircle } from "lucide-react";
 import type { Product } from "@/lib/schema";
+import { useLanguage } from "@/lib/i18n";
 
 interface AllocationBannerProps {
   product: Product;
@@ -9,6 +10,7 @@ interface AllocationBannerProps {
 }
 
 export function AllocationBanner({ product, allocated }: AllocationBannerProps) {
+  const { t } = useLanguage();
   const delta = product.quantity - allocated;
 
   return (
@@ -32,7 +34,7 @@ export function AllocationBanner({ product, allocated }: AllocationBannerProps) 
 
         <div className="flex flex-1 items-center justify-between">
           <div className="text-sm">
-            <span className="font-medium">Allocated: </span>
+            <span className="font-medium">{t("locationAllocationBanner.allocatedLabel")} </span>
             <span className="font-mono">{allocated}</span>
             <span className="text-muted-foreground"> / {product.quantity}</span>
           </div>
@@ -48,10 +50,10 @@ export function AllocationBanner({ product, allocated }: AllocationBannerProps) 
             }
           >
             {delta === 0
-              ? "Balanced"
+              ? t("locationAllocationBanner.balanced")
               : delta > 0
-                ? `Unallocated: +${delta}`
-                : `Exceeded: ${delta}`}
+                ? t("locationAllocationBanner.unallocated", { delta })
+                : t("locationAllocationBanner.exceeded", { delta })}
           </Badge>
         </div>
       </CardContent>

--- a/src/components/pages/location-delete-dialog.tsx
+++ b/src/components/pages/location-delete-dialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import type { ProductLocationView } from "@/lib/schema";
+import { useLanguage } from "@/lib/i18n";
 
 interface DeleteLocationDialogProps {
   entry: ProductLocationView | null;
@@ -23,26 +24,29 @@ export function DeleteLocationDialog({
   onConfirm,
   isPending,
 }: DeleteLocationDialogProps) {
+  const { t } = useLanguage();
+
   return (
     <AlertDialog open={Boolean(entry)} onOpenChange={(open) => !open && onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Remove location?</AlertDialogTitle>
+          <AlertDialogTitle>{t("locationDeleteDialog.title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            The link between this product and location{" "}
-            <strong>{entry?.location_label}</strong> will be removed.{" "}
-            {entry?.quantity} unit(s) will return to the unallocated balance.
+            {t("locationDeleteDialog.confirmMessagePart1", {
+              label: entry?.location_label ?? "",
+            })}{" "}
+            {t.plural("locationDeleteDialog.unitsReturn", entry?.quantity ?? 0)}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             data-testid="button-confirm-delete-location"
           >
-            {isPending ? "Removing..." : "Remove"}
+            {isPending ? t("common.removing") : t("common.remove")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/pages/location-entries-table.tsx
+++ b/src/components/pages/location-entries-table.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import { Pencil, Trash2 } from "lucide-react";
 import type { ProductLocationView } from "@/lib/schema";
+import { useLanguage } from "@/lib/i18n";
 
 interface LocationsTableProps {
   entries: ProductLocationView[];
@@ -31,24 +32,26 @@ export function LocationsTable({
   onDelete,
   onSubmitQuantity,
 }: LocationsTableProps) {
+  const { t } = useLanguage();
+
   return (
     <Card>
       <CardContent className="p-0">
         {isLoading ? (
           <div className="py-12 text-center text-sm text-muted-foreground">
-            Loading...
+            {t("common.loading")}
           </div>
         ) : entries.length === 0 ? (
           <div className="py-12 text-center text-sm text-muted-foreground">
-            This product has no linked locations yet
+            {t("locationEntriesTable.empty")}
           </div>
         ) : (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Location</TableHead>
-                <TableHead className="text-right">Quantity</TableHead>
-                <TableHead className="w-[90px] text-right">Actions</TableHead>
+                <TableHead>{t("locationEntriesTable.locationHeader")}</TableHead>
+                <TableHead className="text-right">{t("locationEntriesTable.quantityHeader")}</TableHead>
+                <TableHead className="w-[90px] text-right">{t("common.actionsHeader")}</TableHead>
               </TableRow>
             </TableHeader>
 

--- a/src/components/pages/location-form.tsx
+++ b/src/components/pages/location-form.tsx
@@ -18,16 +18,17 @@ import { AllocationBanner } from "./location-allocation-banner";
 import { LocationsTable } from "./location-entries-table";
 import { AddLocationDialog } from "./location-add-dialog";
 import { DeleteLocationDialog } from "./location-delete-dialog";
+import { useLanguage, type Translate } from "@/lib/i18n";
 
 interface ProductLocationsFormProps {
   product: Product;
   onClose: () => void;
 }
 
-function getLocationMutationMessage(error: unknown) {
+function getLocationMutationMessage(error: unknown, t: Translate) {
   const status = getErrorStatus(error);
-  if (status === 403) return "You do not have permission to manage locations.";
-  if (status === 409) return "This location is already linked to the product.";
+  if (status === 403) return t("locationForm.forbidden");
+  if (status === 409) return t("locationForm.alreadyLinked");
   return getErrorMessage(error);
 }
 
@@ -36,6 +37,7 @@ export default function LocationForm({
   onClose,
 }: ProductLocationsFormProps) {
   const { toast } = useToast();
+  const { t } = useLanguage();
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingEntry, setEditingEntry] = useState<ProductLocationView | null>(
@@ -87,8 +89,8 @@ export default function LocationForm({
 
   function showMutationError(error: unknown) {
     toast({
-      title: "Error",
-      description: getLocationMutationMessage(error),
+      title: t("common.error"),
+      description: getLocationMutationMessage(error, t),
       variant: "destructive",
     });
   }
@@ -99,7 +101,7 @@ export default function LocationForm({
     },
     onSuccess: () => {
       invalidateEntries();
-      toast({ title: "Location added" });
+      toast({ title: t("locationForm.locationAddedToast") });
       closeAddDialog();
     },
     onError: showMutationError,
@@ -111,7 +113,7 @@ export default function LocationForm({
     },
     onSuccess: () => {
       invalidateEntries();
-      toast({ title: "Quantity updated" });
+      toast({ title: t("locationForm.quantityUpdatedToast") });
       setEditingEntry(null);
     },
     onError: showMutationError,
@@ -123,7 +125,7 @@ export default function LocationForm({
     },
     onSuccess: () => {
       invalidateEntries();
-      toast({ title: "Location removed" });
+      toast({ title: t("locationForm.locationRemovedToast") });
       setDeletingEntry(null);
     },
     onError: showMutationError,
@@ -142,10 +144,13 @@ export default function LocationForm({
         </Button>
         <div>
           <h1 className="text-xl font-semibold tracking-tight">
-            Locations: {product.name}
+            {t("locationForm.backTitle", { name: product.name })}
           </h1>
           <p className="mt-0.5 text-sm text-muted-foreground">
-            SKU: {product.sku} · Total quantity: {product.quantity}
+            {t("locationForm.metaLine", {
+              sku: product.sku,
+              quantity: product.quantity,
+            })}
           </p>
         </div>
       </div>
@@ -155,8 +160,8 @@ export default function LocationForm({
       <div className="mb-2 flex items-center justify-between">
         <h2 className="text-sm font-medium text-muted-foreground">
           {entries.length === 0
-            ? "No linked locations"
-            : `${entries.length} location${entries.length === 1 ? "" : "s"}`}
+            ? t("locationForm.noLinkedLocations")
+            : t.plural("locationForm.linkedLocationsCount", entries.length)}
         </h2>
         <Button
           size="sm"
@@ -165,7 +170,7 @@ export default function LocationForm({
           data-testid="button-add-location"
         >
           <Plus className="mr-2 h-4 w-4" />
-          Add location
+          {t("locationForm.addLocation")}
         </Button>
       </div>
 

--- a/src/components/pages/location-search.tsx
+++ b/src/components/pages/location-search.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { Location } from "@/lib/schema";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { useLanguage } from "@/lib/i18n";
 
 interface LocationSearchProps {
   value: string;
@@ -19,6 +20,7 @@ export function LocationSearch({
   excludeIds,
   initialLabel = "",
 }: LocationSearchProps) {
+  const { t } = useLanguage();
   const excluded = excludeIds ?? [];
   const [input, setInput] = useState(initialLabel);
   const [open, setOpen] = useState(false);
@@ -51,7 +53,7 @@ export function LocationSearch({
   return (
     <div className="relative">
       <Input
-        placeholder="Enter label... (R001C007L10)"
+        placeholder={t("locationSearch.placeholder")}
         value={input}
         onChange={(e) => handleInput(e.target.value)}
         onFocus={() => input.length >= 2 && setOpen(true)}
@@ -83,7 +85,7 @@ export function LocationSearch({
       )}
       {open && input.length >= 2 && available.length === 0 && (
         <div className="absolute z-50 w-full mt-1 bg-popover border border-border rounded-md shadow-md px-3 py-4 text-sm text-muted-foreground text-center">
-          No locations found
+          {t("locationSearch.noResults")}
         </div>
       )}
     </div>

--- a/src/components/pages/locations.tsx
+++ b/src/components/pages/locations.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/table";
 import { Search, Pencil, ArrowUpDown } from "lucide-react";
 import LocationForm from "@/components/pages/location-form";
+import { useLanguage } from "@/lib/i18n";
 
 type SortKey = "label" | "sku" | "category";
 type SortDir = "asc" | "desc";
@@ -65,6 +66,7 @@ function getSortValue(product: Product, sortKey: SortKey): string {
 }
 
 export default function LocationsPage() {
+  const { t, language } = useLanguage();
   const [search, setSearch] = useState("");
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>("label");
@@ -92,7 +94,7 @@ export default function LocationsPage() {
       const res = await fetch(url, { signal });
 
       if (!res.ok) {
-        throw new Error("Failed to fetch products");
+        throw new Error(t("locations.loadErrorFallback"));
       }
 
       return (await res.json()) as Product[];
@@ -103,11 +105,11 @@ export default function LocationsPage() {
     return [...products].sort((a, b) => {
       const aValue = getSortValue(a, sortKey);
       const bValue = getSortValue(b, sortKey);
-      const cmp = aValue.localeCompare(bValue, "uk", { sensitivity: "base" });
+      const cmp = aValue.localeCompare(bValue, language, { sensitivity: "base" });
 
       return sortDir === "asc" ? cmp : -cmp;
     });
-  }, [products, sortKey, sortDir]);
+  }, [products, sortKey, sortDir, language]);
 
   function toggleSort(key: SortKey) {
     if (sortKey === key) {
@@ -135,10 +137,10 @@ export default function LocationsPage() {
           className="text-xl font-semibold tracking-tight"
           data-testid="text-page-title"
         >
-          Locations
+          {t("locations.title")}
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Select a product to manage its warehouse locations
+          {t("locations.subtitle")}
         </p>
       </div>
 
@@ -146,7 +148,7 @@ export default function LocationsPage() {
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="search"
-          placeholder="Search products..."
+          placeholder={t("locations.searchPlaceholder")}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className="pl-9"
@@ -159,7 +161,7 @@ export default function LocationsPage() {
           {isLoading ? (
             <div className="flex items-center justify-center py-16">
               <div className="text-sm text-muted-foreground">
-                Loading products...
+                {t("common.loadingProducts")}
               </div>
             </div>
           ) : isError ? (
@@ -167,12 +169,14 @@ export default function LocationsPage() {
               <div className="text-sm text-destructive">
                 {error instanceof Error
                   ? error.message
-                  : "Failed to load products"}
+                  : t("locations.loadErrorFallback")}
               </div>
             </div>
           ) : sortedProducts.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16">
-              <p className="text-sm text-muted-foreground">No products found</p>
+              <p className="text-sm text-muted-foreground">
+                {t("common.noProductsFound")}
+              </p>
               {search ? (
                 <Button
                   variant="ghost"
@@ -181,7 +185,7 @@ export default function LocationsPage() {
                   onClick={() => setSearch("")}
                   data-testid="button-clear-search"
                 >
-                  Clear search
+                  {t("locations.clearSearch")}
                 </Button>
               ) : null}
             </div>
@@ -192,7 +196,7 @@ export default function LocationsPage() {
                   <TableHead>
                     <SortButton
                       column="label"
-                      label="Product"
+                      label={t("locations.productHeader")}
                       activeKey={sortKey}
                       activeDir={sortDir}
                       onToggle={toggleSort}
@@ -201,7 +205,7 @@ export default function LocationsPage() {
                   <TableHead className="w-[120px]">
                     <SortButton
                       column="sku"
-                      label="SKU"
+                      label={t("fields.sku")}
                       activeKey={sortKey}
                       activeDir={sortDir}
                       onToggle={toggleSort}
@@ -210,14 +214,14 @@ export default function LocationsPage() {
                   <TableHead className="w-[120px]">
                     <SortButton
                       column="category"
-                      label="Category"
+                      label={t("fields.category")}
                       activeKey={sortKey}
                       activeDir={sortDir}
                       onToggle={toggleSort}
                     />
                   </TableHead>
                   <TableHead className="w-[90px] text-right">
-                    Locations
+                    {t("nav.locations")}
                   </TableHead>
                 </TableRow>
               </TableHeader>

--- a/src/components/pages/login.tsx
+++ b/src/components/pages/login.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { loginSchema, type LoginInput } from "@/lib/schema";
 import { useAuth } from "@/hooks/use-auth";
+import { useLanguage } from "@/lib/i18n";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
@@ -20,6 +21,7 @@ import { Shield, Loader2 } from "lucide-react";
 
 export default function LoginPage() {
   const { login } = useAuth();
+  const { t } = useLanguage();
   const [isPending, setIsPending] = useState(false);
 
   const form = useForm<LoginInput>({
@@ -52,7 +54,7 @@ export default function LoginPage() {
               StockPulse
             </h1>
             <p className="text-sm text-muted-foreground mt-1">
-              Warehouse management system
+              {t("login.subtitle")}
             </p>
           </div>
         </div>
@@ -60,7 +62,9 @@ export default function LoginPage() {
         {/* Login Card */}
         <Card className="border-border/50">
           <CardHeader className="pb-4 pt-5 px-5">
-            <p className="text-sm font-medium text-foreground">System login</p>
+            <p className="text-sm font-medium text-foreground">
+              {t("login.cardHeading")}
+            </p>
           </CardHeader>
           <CardContent className="px-5 pb-5">
             <Form {...form}>
@@ -74,11 +78,11 @@ export default function LoginPage() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel className="text-xs font-medium">
-                        Username
+                        {t("fields.username")}
                       </FormLabel>
                       <FormControl>
                         <Input
-                          placeholder="Enter username"
+                          placeholder={t("login.usernamePlaceholder")}
                           autoComplete="username"
                           data-testid="input-username"
                           {...field}
@@ -95,12 +99,12 @@ export default function LoginPage() {
                   render={({ field }) => (
                     <FormItem>
                       <FormLabel className="text-xs font-medium">
-                        Password
+                        {t("fields.password")}
                       </FormLabel>
                       <FormControl>
                         <Input
                           type="password"
-                          placeholder="Enter password"
+                          placeholder={t("login.passwordPlaceholder")}
                           autoComplete="current-password"
                           data-testid="input-password"
                           {...field}
@@ -120,10 +124,10 @@ export default function LoginPage() {
                   {isPending ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Signing in…
+                      {t("login.signingIn")}
                     </>
                   ) : (
-                    "Sign in"
+                    t("login.signIn")
                   )}
                 </Button>
               </form>
@@ -132,7 +136,7 @@ export default function LoginPage() {
         </Card>
 
         <p className="text-center text-xs text-muted-foreground">
-          Access is granted by the system administrator
+          {t("login.footerNote")}
         </p>
       </div>
     </div>

--- a/src/components/pages/logs-filters.tsx
+++ b/src/components/pages/logs-filters.tsx
@@ -1,6 +1,7 @@
 import { Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { AuditAction } from "./logs-table";
+import { useLanguage } from "@/lib/i18n";
 
 interface LogsFiltersProps {
   query: string;
@@ -25,6 +26,8 @@ export function LogsFilters({
   onApply,
   onReset,
 }: LogsFiltersProps) {
+  const { t } = useLanguage();
+
   return (
     <div className="rounded-lg border bg-card p-4 space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-[1fr_180px_180px_auto_auto] gap-3">
@@ -33,7 +36,7 @@ export function LogsFilters({
           <input
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
-            placeholder="Search table, record ID, correlation ID..."
+            placeholder={t("logsFilters.searchPlaceholder")}
             className="w-full h-10 rounded-md border bg-background pl-9 pr-3 text-sm outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring"
             data-testid="input-logs-search"
           />
@@ -45,7 +48,7 @@ export function LogsFilters({
           className="h-10 rounded-md border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-testid="select-logs-table"
         >
-          <option value="all">All tables</option>
+          <option value="all">{t("logsFilters.allTables")}</option>
           {tableOptions.map((table_name, index) => (
             <option key={`table-${table_name}-${index}`} value={table_name}>
               {table_name}
@@ -59,18 +62,18 @@ export function LogsFilters({
           className="h-10 rounded-md border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-testid="select-logs-action"
         >
-          <option value="all">All actions</option>
+          <option value="all">{t("logsFilters.allActions")}</option>
           <option value="INSERT">INSERT</option>
           <option value="UPDATE">UPDATE</option>
           <option value="DELETE">DELETE</option>
         </select>
 
         <Button onClick={onApply} data-testid="button-apply-logs-filters">
-          Apply
+          {t("logsFilters.apply")}
         </Button>
 
         <Button variant="outline" onClick={onReset} data-testid="button-reset-logs-filters">
-          Reset
+          {t("logsFilters.reset")}
         </Button>
       </div>
     </div>

--- a/src/components/pages/logs-table.tsx
+++ b/src/components/pages/logs-table.tsx
@@ -6,6 +6,7 @@ import {
   PermissionDotsHint,
 } from "@/components/pages/permission-dots";
 import { PERMISSIONS, type Permission } from "@/lib/permissions";
+import { useLanguage } from "@/lib/i18n";
 
 const PERMISSION_VALUES = new Set<string>(Object.values(PERMISSIONS));
 
@@ -51,13 +52,19 @@ function formatAuditValue(value: unknown): string {
 
 function AuditObjectView({
   value,
-  emptyLabel = "No data",
+  emptyLabel,
 }: {
   value: Record<string, unknown> | null | undefined;
   emptyLabel?: string;
 }) {
+  const { t } = useLanguage();
+
   if (!value || Object.keys(value).length === 0) {
-    return <span className="text-muted-foreground">{emptyLabel}</span>;
+    return (
+      <span className="text-muted-foreground">
+        {emptyLabel ?? t("logsTable.noData")}
+      </span>
+    );
   }
 
   return (
@@ -86,13 +93,16 @@ function AuditNewValues({
 }: {
   newValues: Record<string, unknown> | null;
 }) {
+  const { t } = useLanguage();
   const diff = newValues?.diff;
 
   if (diff && typeof diff === "object" && !Array.isArray(diff)) {
     const entries = Object.entries(diff as Record<string, unknown>);
 
     if (entries.length === 0) {
-      return <span className="text-muted-foreground">No changes</span>;
+      return (
+        <span className="text-muted-foreground">{t("logsTable.noChanges")}</span>
+      );
     }
 
     return (
@@ -111,7 +121,7 @@ function AuditNewValues({
                 {isPermissionsField && <PermissionDotsHint />}
               </div>
               <div className="mt-1 grid grid-cols-[80px_minmax(0,1fr)] items-center gap-x-2 gap-y-1.5">
-                <span className="text-muted-foreground">Old</span>
+                <span className="text-muted-foreground">{t("logsTable.old")}</span>
                 {isPermissionsField ? (
                   <PermissionDots permissions={typedChange.old as Permission[]} />
                 ) : (
@@ -119,7 +129,7 @@ function AuditNewValues({
                     {JSON.stringify(typedChange.old)}
                   </code>
                 )}
-                <span className="text-muted-foreground">New</span>
+                <span className="text-muted-foreground">{t("logsTable.new")}</span>
                 {isPermissionsField ? (
                   <PermissionDots permissions={typedChange.new as Permission[]} />
                 ) : (
@@ -135,7 +145,9 @@ function AuditNewValues({
     );
   }
 
-  return <AuditObjectView value={newValues} emptyLabel="No new values" />;
+  return (
+    <AuditObjectView value={newValues} emptyLabel={t("logsTable.noNewValues")} />
+  );
 }
 
 interface LogsTableProps {
@@ -151,12 +163,14 @@ export function LogsTable({
   expandedRows,
   onToggleRow,
 }: LogsTableProps) {
+  const { t, language } = useLanguage();
+
   if (loading) {
     return (
       <div className="rounded-lg border bg-card overflow-hidden">
         <div className="flex items-center justify-center gap-2 py-16 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
-          Loading audit logs...
+          {t("logsTable.loading")}
         </div>
       </div>
     );
@@ -166,7 +180,7 @@ export function LogsTable({
     return (
       <div className="rounded-lg border bg-card overflow-hidden">
         <div className="py-16 text-center text-sm text-muted-foreground">
-          No audit logs found.
+          {t("logsTable.empty")}
         </div>
       </div>
     );
@@ -179,11 +193,11 @@ export function LogsTable({
           <thead className="bg-muted/40 border-b">
             <tr className="text-left">
               <th className="w-[44px] px-4 py-3"></th>
-              <th className="px-4 py-3 font-medium">Entity</th>
-              <th className="px-4 py-3 font-medium">Action</th>
-              <th className="px-4 py-3 font-medium">Actor</th>
-              <th className="px-4 py-3 font-medium">Correlation ID</th>
-              <th className="px-4 py-3 font-medium">Created At</th>
+              <th className="px-4 py-3 font-medium">{t("logsTable.entityHeader")}</th>
+              <th className="px-4 py-3 font-medium">{t("logsTable.actionHeader")}</th>
+              <th className="px-4 py-3 font-medium">{t("logsTable.actorHeader")}</th>
+              <th className="px-4 py-3 font-medium">{t("logsTable.correlationIdHeader")}</th>
+              <th className="px-4 py-3 font-medium">{t("logsTable.createdAtHeader")}</th>
             </tr>
           </thead>
           <tbody>
@@ -198,7 +212,9 @@ export function LogsTable({
                         onClick={() => onToggleRow(log.id)}
                         className="inline-flex h-7 w-7 items-center justify-center rounded-md border hover:bg-muted"
                         aria-label={
-                          expanded ? "Collapse log details" : "Expand log details"
+                          expanded
+                            ? t("logsTable.collapseDetails")
+                            : t("logsTable.expandDetails")
                         }
                       >
                         {expanded ? (
@@ -212,7 +228,7 @@ export function LogsTable({
                     <td className="px-4 py-3">
                       <div className="font-medium">{log.table_name}</div>
                       <div className="break-all text-xs text-muted-foreground">
-                        {log.record_id ?? "No record ID"}
+                        {log.record_id ?? t("logsTable.noRecordId")}
                       </div>
                     </td>
 
@@ -228,7 +244,7 @@ export function LogsTable({
 
                     <td className="px-4 py-3">
                       <div>
-                        {log.actorUsername ?? log.actorFullName ?? "System"}
+                        {log.actorUsername ?? log.actorFullName ?? t("logsTable.system")}
                       </div>
                       {log.actor_user_id && (
                         <div className="break-all text-xs text-muted-foreground">
@@ -242,7 +258,7 @@ export function LogsTable({
                     </td>
 
                     <td className="whitespace-nowrap px-4 py-3 text-muted-foreground">
-                      {new Date(log.created_at).toLocaleString()}
+                      {new Date(log.created_at).toLocaleString(language)}
                     </td>
                   </tr>
 
@@ -251,11 +267,11 @@ export function LogsTable({
                       <td colSpan={6} className="px-4 py-4">
                         <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
                           <section className="space-y-2">
-                            <h3 className="text-sm font-medium">Old values</h3>
+                            <h3 className="text-sm font-medium">{t("logsTable.oldValues")}</h3>
                             <div className="rounded-md border bg-background p-3">
                               <AuditObjectView
                                 value={log.old_values}
-                                emptyLabel="No previous values"
+                                emptyLabel={t("logsTable.noPreviousValues")}
                               />
                             </div>
                           </section>
@@ -264,8 +280,8 @@ export function LogsTable({
                             <h3 className="text-sm font-medium">
                               {log.action === "UPDATE" ||
                               log.action === "REPLACE_PERMISSIONS"
-                                ? "Changes"
-                                : "New values"}
+                                ? t("logsTable.changes")
+                                : t("logsTable.newValues")}
                             </h3>
                             <div className="rounded-md border bg-background p-3">
                               <AuditNewValues newValues={log.new_values} />

--- a/src/components/pages/logs.tsx
+++ b/src/components/pages/logs.tsx
@@ -7,8 +7,10 @@ import { Card, CardContent } from "@/components/ui/card";
 import { createApiClientErrorFromResponse } from "@/lib/apiClientError";
 import { LogsFilters } from "./logs-filters";
 import { LogsTable, type AuditAction, type AuditLogItem } from "./logs-table";
+import { useLanguage } from "@/lib/i18n";
 
 export default function LogsPage() {
+  const { t } = useLanguage();
   const [logs, setLogs] = useState<AuditLogItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -42,7 +44,7 @@ export default function LogsPage() {
         if (!res.ok) {
           const apiError = await createApiClientErrorFromResponse(
             res,
-            "Failed to fetch audit logs",
+            t("logs.fetchError"),
           );
           setLoadError(apiError.message);
           setLogs([]);
@@ -54,7 +56,7 @@ export default function LogsPage() {
         setLogs(Array.isArray(data) ? data : []);
       } catch (error) {
         setLoadError(
-          error instanceof Error ? error.message : "Failed to fetch audit logs",
+          error instanceof Error ? error.message : t("logs.fetchError"),
         );
         setLogs([]);
       } finally {
@@ -62,7 +64,7 @@ export default function LogsPage() {
         setRefreshing(false);
       }
     },
-    [query, selectedTable, selectedAction],
+    [query, selectedTable, selectedAction, t],
   );
 
   useEffect(() => {
@@ -93,9 +95,9 @@ export default function LogsPage() {
     <section className="space-y-6" data-testid="logs-page">
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
-          <h1 className="text-2xl font-semibold tracking-tight">Audit Logs</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">{t("logs.title")}</h1>
           <p className="text-sm text-muted-foreground">
-            History of changes across system entities and user actions.
+            {t("logs.subtitle")}
           </p>
         </div>
 
@@ -109,7 +111,7 @@ export default function LogsPage() {
           <RefreshCw
             className={`h-4 w-4 ${refreshing ? "animate-spin" : ""}`}
           />
-          Refresh
+          {t("logs.refresh")}
         </Button>
       </div>
 

--- a/src/components/pages/permission-dots.tsx
+++ b/src/components/pages/permission-dots.tsx
@@ -10,11 +10,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { PERMISSIONS, type Permission } from "@/lib/permissions";
+import { useLanguage, type TranslationKey } from "@/lib/i18n";
 
 type AccessLevel = "none" | "read" | "write";
 
 interface PermissionResource {
-  label: string;
+  id: string;
+  labelKey: TranslationKey;
   read: Permission;
   write?: Permission;
   del?: Permission;
@@ -22,24 +24,27 @@ interface PermissionResource {
 
 const RESOURCES: PermissionResource[] = [
   {
-    label: "Products",
+    id: "products",
+    labelKey: "nav.products",
     read: PERMISSIONS.READ_PRODUCTS,
     write: PERMISSIONS.WRITE_PRODUCTS,
     del: PERMISSIONS.DELETE_PRODUCTS,
   },
   {
-    label: "Locations",
+    id: "locations",
+    labelKey: "nav.locations",
     read: PERMISSIONS.READ_LOCATIONS,
     write: PERMISSIONS.WRITE_LOCATIONS,
     del: PERMISSIONS.DELETE_LOCATIONS,
   },
   {
-    label: "Users",
+    id: "users",
+    labelKey: "nav.users",
     read: PERMISSIONS.READ_USERS,
     write: PERMISSIONS.WRITE_USERS,
     del: PERMISSIONS.DELETE_USERS,
   },
-  { label: "Logs", read: PERMISSIONS.READ_LOGS },
+  { id: "logs", labelKey: "permissionDots.logs", read: PERMISSIONS.READ_LOGS },
 ];
 
 const levelStyles: Record<AccessLevel, string> = {
@@ -48,10 +53,10 @@ const levelStyles: Record<AccessLevel, string> = {
   write: "bg-emerald-500",
 };
 
-const levelLabel: Record<AccessLevel, string> = {
-  none: "No access",
-  read: "Can view",
-  write: "Can edit",
+const levelLabelKeys: Record<AccessLevel, TranslationKey> = {
+  none: "permissionDots.noAccess",
+  read: "permissionDots.canView",
+  write: "permissionDots.canEdit",
 };
 
 function accessLevel(
@@ -69,41 +74,47 @@ function accessLevel(
 }
 
 export function PermissionDotsHint() {
+  const { t } = useLanguage();
+
   return (
     <Popover>
       <PopoverTrigger asChild>
         <button
           type="button"
           className="inline-flex cursor-help text-muted-foreground"
-          aria-label="Explain permission dot order"
+          aria-label={t("permissionDots.hintAriaLabel")}
           data-testid="permission-dots-hint"
         >
           <Info className="h-3.5 w-3.5" />
         </button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-2 text-xs" sideOffset={4}>
-        Dot order: {RESOURCES.map((r) => r.label).join(", ")}
+        {t("permissionDots.hintPrefix", {
+          list: RESOURCES.map((r) => t(r.labelKey)).join(", "),
+        })}
       </PopoverContent>
     </Popover>
   );
 }
 
 export function PermissionDots({ permissions }: { permissions: Permission[] }) {
+  const { t } = useLanguage();
+
   return (
     <div className="flex items-center gap-1.5" data-testid="permission-dots">
       {RESOURCES.map((resource) => {
         const level = accessLevel(permissions, resource);
 
         return (
-          <Tooltip key={resource.label}>
+          <Tooltip key={resource.id}>
             <TooltipTrigger asChild>
               <span
                 className={`h-2.5 w-2.5 shrink-0 rounded-full ${levelStyles[level]}`}
-                data-testid={`permission-dot-${resource.label.toLowerCase()}-${level}`}
+                data-testid={`permission-dot-${resource.id}-${level}`}
               />
             </TooltipTrigger>
             <TooltipContent>
-              {resource.label}: {levelLabel[level]}
+              {t(resource.labelKey)}: {t(levelLabelKeys[level])}
             </TooltipContent>
           </Tooltip>
         );

--- a/src/components/pages/product-form.tsx
+++ b/src/components/pages/product-form.tsx
@@ -28,21 +28,23 @@ import {
 } from "@/components/ui/form";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft } from "lucide-react";
+import { useLanguage, type Translate } from "@/lib/i18n";
 
 interface ProductFormProps {
   product?: Product;
   onClose: () => void;
 }
 
-function getProductMutationMessage(error: unknown) {
+function getProductMutationMessage(error: unknown, t: Translate) {
   const status = getErrorStatus(error);
-  if (status === 403) return "You do not have permission to manage products.";
-  if (status === 409) return "A product with this SKU already exists.";
+  if (status === 403) return t("productForm.forbidden");
+  if (status === 409) return t("productForm.skuConflict");
   return getErrorMessage(error);
 }
 
 export default function ProductForm({ product, onClose }: ProductFormProps) {
   const { toast } = useToast();
+  const { t } = useLanguage();
   const isEditing = !!product;
 
   const form = useForm<InsertProduct>({
@@ -72,18 +74,23 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
       queryClient.invalidateQueries({ queryKey: ["/api/categories"] });
 
       toast({
-        title: isEditing ? "Product updated" : "Product created",
+        title: isEditing
+          ? t("productForm.updatedToastTitle")
+          : t("productForm.createdToastTitle"),
         description: isEditing
-          ? "The product has been updated successfully."
-          : "The product has been added to inventory.",
+          ? t("productForm.updatedToastDescription")
+          : t("productForm.createdToastDescription"),
       });
 
       onClose();
     },
     onError: (error: ApiClientError) => {
       toast({
-        title: getErrorStatus(error) === 403 ? "Access denied" : "Error",
-        description: getProductMutationMessage(error),
+        title:
+          getErrorStatus(error) === 403
+            ? t("common.accessDenied")
+            : t("common.error"),
+        description: getProductMutationMessage(error, t),
         variant: "destructive",
       });
     },
@@ -110,12 +117,12 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
             className="text-xl font-semibold tracking-tight"
             data-testid="text-form-title"
           >
-            {isEditing ? "Edit Product" : "Add Product"}
+            {isEditing ? t("productForm.editTitle") : t("products.addProduct")}
           </h1>
           <p className="mt-0.5 text-sm text-muted-foreground">
             {isEditing
-              ? "Update the product details below"
-              : "Fill in the product details below"}
+              ? t("productForm.editSubtitle")
+              : t("productForm.addSubtitle")}
           </p>
         </div>
       </div>
@@ -130,10 +137,10 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   name="name"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Product Name</FormLabel>
+                      <FormLabel>{t("productForm.nameLabel")}</FormLabel>
                       <FormControl>
                         <Input
-                          placeholder="e.g. Wireless Mouse"
+                          placeholder={t("productForm.namePlaceholder")}
                           {...field}
                           data-testid="input-name"
                         />
@@ -148,10 +155,10 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   name="sku"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>SKU</FormLabel>
+                      <FormLabel>{t("fields.sku")}</FormLabel>
                       <FormControl>
                         <Input
-                          placeholder="e.g. WM-001"
+                          placeholder={t("productForm.skuPlaceholder")}
                           {...field}
                           data-testid="input-sku"
                         />
@@ -167,10 +174,10 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                 name="category"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Category</FormLabel>
+                    <FormLabel>{t("fields.category")}</FormLabel>
                     <FormControl>
                       <Input
-                        placeholder="e.g. Electronics"
+                        placeholder={t("productForm.categoryPlaceholder")}
                         {...field}
                         data-testid="input-category"
                       />
@@ -186,7 +193,7 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   name="quantity"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Quantity</FormLabel>
+                      <FormLabel>{t("fields.quantity")}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -209,7 +216,7 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   name="price"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Price ($)</FormLabel>
+                      <FormLabel>{t("productForm.priceLabel")}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -232,7 +239,7 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   name="low_stock_threshold"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Low Stock Alert</FormLabel>
+                      <FormLabel>{t("productForm.lowStockLabel")}</FormLabel>
                       <FormControl>
                         <Input
                           type="number"
@@ -256,10 +263,10 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                 name="description"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Description</FormLabel>
+                    <FormLabel>{t("productForm.descriptionLabel")}</FormLabel>
                     <FormControl>
                       <Textarea
-                        placeholder="Optional product description..."
+                        placeholder={t("productForm.descriptionPlaceholder")}
                         rows={3}
                         {...field}
                         value={field.value ?? ""}
@@ -279,11 +286,11 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                 >
                   {mutation.isPending
                     ? isEditing
-                      ? "Updating..."
-                      : "Creating..."
+                      ? t("productForm.updating")
+                      : t("common.creating")
                     : isEditing
-                      ? "Update Product"
-                      : "Create Product"}
+                      ? t("productForm.updateProduct")
+                      : t("productForm.createProduct")}
                 </Button>
 
                 <Button
@@ -292,7 +299,7 @@ export default function ProductForm({ product, onClose }: ProductFormProps) {
                   onClick={onClose}
                   data-testid="button-cancel"
                 >
-                  Cancel
+                  {t("common.cancel")}
                 </Button>
               </div>
             </form>

--- a/src/components/pages/products-delete-dialog.tsx
+++ b/src/components/pages/products-delete-dialog.tsx
@@ -9,6 +9,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import type { Product } from "@/lib/schema";
+import { useLanguage } from "@/lib/i18n";
 
 interface DeleteProductDialogProps {
   product: Product | null;
@@ -23,27 +24,30 @@ export function DeleteProductDialog({
   onConfirm,
   isPending,
 }: DeleteProductDialogProps) {
+  const { t } = useLanguage();
+
   return (
     <AlertDialog open={Boolean(product)} onOpenChange={() => onClose()}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete Product</AlertDialogTitle>
+          <AlertDialogTitle>{t("productsDeleteDialog.title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            Are you sure you want to delete &quot;{product?.name}&quot;? This
-            action cannot be undone.
+            {t("productsDeleteDialog.confirmMessage", {
+              name: product?.name ?? "",
+            })}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
         <AlertDialogFooter>
           <AlertDialogCancel data-testid="button-cancel-delete">
-            Cancel
+            {t("common.cancel")}
           </AlertDialogCancel>
           <AlertDialogAction
             onClick={onConfirm}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             data-testid="button-confirm-delete"
           >
-            {isPending ? "Deleting..." : "Delete"}
+            {isPending ? t("common.deleting") : t("common.delete")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/pages/products-filters.tsx
+++ b/src/components/pages/products-filters.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useLanguage } from "@/lib/i18n";
 
 interface ProductsFiltersProps {
   search: string;
@@ -23,13 +24,15 @@ export function ProductsFilters({
   onCategoryChange,
   categories,
 }: ProductsFiltersProps) {
+  const { t } = useLanguage();
+
   return (
     <div className="flex flex-col gap-3 sm:flex-row">
       <div className="relative flex-1">
         <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="search"
-          placeholder="Search by name, SKU, or description..."
+          placeholder={t("productsFilters.searchPlaceholder")}
           value={search}
           onChange={(e) => onSearchChange(e.target.value)}
           className="pl-9"
@@ -42,10 +45,10 @@ export function ProductsFilters({
           className="w-full sm:w-[180px]"
           data-testid="select-category-filter"
         >
-          <SelectValue placeholder="All Categories" />
+          <SelectValue placeholder={t("productsFilters.allCategories")} />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">All Categories</SelectItem>
+          <SelectItem value="all">{t("productsFilters.allCategories")}</SelectItem>
           {categories.map((cat) => (
             <SelectItem key={cat} value={cat}>
               {cat}

--- a/src/components/pages/products-table.tsx
+++ b/src/components/pages/products-table.tsx
@@ -12,11 +12,12 @@ import {
 import { Pencil, Trash2, ArrowUpDown } from "lucide-react";
 import { getErrorMessage, getErrorStatus } from "@/lib/apiClientError";
 import type { Product } from "@/lib/schema";
+import { useLanguage, type Translate } from "@/lib/i18n";
 
 export type SortKey = "name" | "sku" | "category" | "quantity" | "price";
 export type SortDir = "asc" | "desc";
 
-function getStockBadge(product: Product) {
+function getStockBadge(product: Product, t: Translate) {
   if (product.quantity === 0) {
     return (
       <Badge
@@ -24,7 +25,7 @@ function getStockBadge(product: Product) {
         className="text-xs"
         data-testid={`status-stock-${product.id}`}
       >
-        Out of stock
+        {t("productsTable.outOfStock")}
       </Badge>
     );
   }
@@ -36,7 +37,7 @@ function getStockBadge(product: Product) {
         className="border-amber-300 text-xs text-amber-600 dark:border-amber-700 dark:text-amber-400"
         data-testid={`status-stock-${product.id}`}
       >
-        Low stock
+        {t("productsTable.lowStock")}
       </Badge>
     );
   }
@@ -47,7 +48,7 @@ function getStockBadge(product: Product) {
       className="border-emerald-300 text-xs text-emerald-600 dark:border-emerald-700 dark:text-emerald-400"
       data-testid={`status-stock-${product.id}`}
     >
-      In stock
+      {t("productsTable.inStock")}
     </Badge>
   );
 }
@@ -114,6 +115,7 @@ export function ProductsTable({
   sortDir,
   onToggleSort,
 }: ProductsTableProps) {
+  const { t } = useLanguage();
   const sortProps = { sortKey, sortDir, onToggle: onToggleSort };
 
   return (
@@ -121,19 +123,23 @@ export function ProductsTable({
       <CardContent className="p-0">
         {isLoading ? (
           <div className="flex items-center justify-center py-16">
-            <div className="text-sm text-muted-foreground">Loading products...</div>
+            <div className="text-sm text-muted-foreground">
+              {t("productsTable.loading")}
+            </div>
           </div>
         ) : isError ? (
           <div className="flex flex-col items-center justify-center py-16">
             <p className="text-sm text-destructive">
               {getErrorStatus(error) === 403
-                ? "You do not have permission to view products."
-                : getErrorMessage(error, "Failed to fetch products.")}
+                ? t("productsTable.forbidden")
+                : getErrorMessage(error, t("productsTable.loadError"))}
             </p>
           </div>
         ) : products.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16">
-            <p className="text-sm text-muted-foreground">No products found</p>
+            <p className="text-sm text-muted-foreground">
+              {t("productsTable.empty")}
+            </p>
             {(search || categoryFilter !== "all") && (
               <Button
                 variant="ghost"
@@ -142,7 +148,7 @@ export function ProductsTable({
                 onClick={onClearFilters}
                 data-testid="button-clear-filters"
               >
-                Clear filters
+                {t("productsTable.clearFilters")}
               </Button>
             )}
           </div>
@@ -151,22 +157,22 @@ export function ProductsTable({
             <TableHeader>
               <TableRow>
                 <TableHead className="w-[280px]">
-                  <SortButton column="name" label="Name" {...sortProps} />
+                  <SortButton column="name" label={t("productsTable.nameHeader")} {...sortProps} />
                 </TableHead>
                 <TableHead className="w-[120px]">
-                  <SortButton column="sku" label="SKU" {...sortProps} />
+                  <SortButton column="sku" label={t("fields.sku")} {...sortProps} />
                 </TableHead>
                 <TableHead className="w-[130px]">
-                  <SortButton column="category" label="Category" {...sortProps} />
+                  <SortButton column="category" label={t("fields.category")} {...sortProps} />
                 </TableHead>
                 <TableHead className="w-[100px] text-right">
-                  <SortButton column="quantity" label="Qty" {...sortProps} />
+                  <SortButton column="quantity" label={t("productsTable.qtyHeader")} {...sortProps} />
                 </TableHead>
                 <TableHead className="w-[100px] text-right">
-                  <SortButton column="price" label="Price" {...sortProps} />
+                  <SortButton column="price" label={t("productsTable.priceHeader")} {...sortProps} />
                 </TableHead>
-                <TableHead className="w-[100px]">Status</TableHead>
-                <TableHead className="w-[90px] text-right">Actions</TableHead>
+                <TableHead className="w-[100px]">{t("fields.status")}</TableHead>
+                <TableHead className="w-[90px] text-right">{t("common.actionsHeader")}</TableHead>
               </TableRow>
             </TableHeader>
 
@@ -202,7 +208,7 @@ export function ProductsTable({
                     ${product.price.toFixed(2)}
                   </TableCell>
 
-                  <TableCell>{getStockBadge(product)}</TableCell>
+                  <TableCell>{getStockBadge(product, t)}</TableCell>
 
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">

--- a/src/components/pages/products.tsx
+++ b/src/components/pages/products.tsx
@@ -16,10 +16,12 @@ import ProductForm from "@/components/pages/product-form";
 import { ProductsFilters } from "./products-filters";
 import { ProductsTable, type SortKey, type SortDir } from "./products-table";
 import { DeleteProductDialog } from "./products-delete-dialog";
+import { useLanguage } from "@/lib/i18n";
 
 async function fetchProducts(
   search: string,
   categoryFilter: string,
+  fallbackMessage: string,
 ): Promise<Product[]> {
   const params = new URLSearchParams();
   if (search) params.set("q", search);
@@ -31,7 +33,7 @@ async function fetchProducts(
   const res = await fetch(url);
 
   if (!res.ok) {
-    throw await createApiClientErrorFromResponse(res, "Failed to fetch products");
+    throw await createApiClientErrorFromResponse(res, fallbackMessage);
   }
 
   return (await res.json()) as Product[];
@@ -39,6 +41,7 @@ async function fetchProducts(
 
 export default function Products() {
   const { toast } = useToast();
+  const { t } = useLanguage();
 
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("all");
@@ -55,7 +58,8 @@ export default function Products() {
     error,
   } = useQuery<Product[]>({
     queryKey: ["/api/products", { q: search, category: categoryFilter }],
-    queryFn: () => fetchProducts(search, categoryFilter),
+    queryFn: () =>
+      fetchProducts(search, categoryFilter, t("productsTable.loadError")),
   });
 
   const { data: categories = [] } = useQuery<string[]>({
@@ -71,18 +75,21 @@ export default function Products() {
       queryClient.invalidateQueries({ queryKey: ["/api/stats"] });
       queryClient.invalidateQueries({ queryKey: ["/api/categories"] });
       toast({
-        title: "Product deleted",
-        description: "The product has been removed from inventory.",
+        title: t("products.deletedToastTitle"),
+        description: t("products.deletedToastDescription"),
       });
       setDeletingProduct(null);
     },
     onError: (error: unknown) => {
       toast({
-        title: getErrorStatus(error) === 403 ? "Access denied" : "Error",
+        title:
+          getErrorStatus(error) === 403
+            ? t("common.accessDenied")
+            : t("common.error"),
         description:
           getErrorStatus(error) === 403
-            ? "You do not have permission to delete products."
-            : getErrorMessage(error, "Failed to delete the product."),
+            ? t("products.deleteForbidden")
+            : getErrorMessage(error, t("products.deleteFailed")),
         variant: "destructive",
       });
     },
@@ -129,16 +136,16 @@ export default function Products() {
             className="text-xl font-semibold tracking-tight"
             data-testid="text-page-title"
           >
-            Products
+            {t("products.title")}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            {products.length} items in inventory
+            {t.plural("products.itemsCount", products.length)}
           </p>
         </div>
 
         <Button onClick={() => setShowForm(true)} data-testid="button-add-product">
           <Plus className="mr-2 h-4 w-4" />
-          Add Product
+          {t("products.addProduct")}
         </Button>
       </div>
 

--- a/src/components/pages/user-form.tsx
+++ b/src/components/pages/user-form.tsx
@@ -31,10 +31,16 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Loader2 } from "lucide-react";
+import {
+  useLanguage,
+  translateRank,
+  translateClearance,
+  type TranslationKey,
+} from "@/lib/i18n";
 
-const PERMISSION_GROUPS: { label: string; perms: Permission[] }[] = [
+const PERMISSION_GROUPS: { labelKey: TranslationKey; perms: Permission[] }[] = [
   {
-    label: "Read",
+    labelKey: "userForm.readGroup",
     perms: [
       PERMISSIONS.READ_PRODUCTS,
       PERMISSIONS.READ_LOCATIONS,
@@ -44,7 +50,7 @@ const PERMISSION_GROUPS: { label: string; perms: Permission[] }[] = [
     ],
   },
   {
-    label: "Write",
+    labelKey: "userForm.writeGroup",
     perms: [
       PERMISSIONS.WRITE_PRODUCTS,
       PERMISSIONS.WRITE_LOCATIONS,
@@ -52,7 +58,7 @@ const PERMISSION_GROUPS: { label: string; perms: Permission[] }[] = [
     ],
   },
   {
-    label: "Delete",
+    labelKey: "userForm.deleteGroup",
     perms: [
       PERMISSIONS.DELETE_PRODUCTS,
       PERMISSIONS.DELETE_LOCATIONS,
@@ -61,18 +67,18 @@ const PERMISSION_GROUPS: { label: string; perms: Permission[] }[] = [
   },
 ];
 
-const PERMISSION_LABELS: Record<Permission, string> = {
-  read_products: "Products",
-  read_locations: "Locations",
-  read_users: "Users",
-  read_debug: "Debug",
-  read_logs: "Logs",
-  write_products: "Products",
-  write_locations: "Locations",
-  write_users: "Users",
-  delete_products: "Products",
-  delete_locations: "Locations",
-  delete_users: "Users",
+const PERMISSION_LABEL_KEYS: Record<Permission, TranslationKey> = {
+  read_products: "nav.products",
+  read_locations: "nav.locations",
+  read_users: "nav.users",
+  read_debug: "userForm.debugLabel",
+  read_logs: "permissionDots.logs",
+  write_products: "nav.products",
+  write_locations: "nav.locations",
+  write_users: "nav.users",
+  delete_products: "nav.products",
+  delete_locations: "nav.locations",
+  delete_users: "nav.users",
 };
 
 type UserFormValues = {
@@ -104,6 +110,7 @@ type EditUserFormProps = {
 type UserFormProps = CreateUserFormProps | EditUserFormProps;
 
 export default function UserForm(props: UserFormProps) {
+  const { t } = useLanguage();
   const form = useForm<UserFormValues>({
     resolver: zodResolver(
       props.isEdit ? updateUserSchema : insertUserSchema,
@@ -159,7 +166,7 @@ export default function UserForm(props: UserFormProps) {
           name="username"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Username</FormLabel>
+              <FormLabel>{t("fields.username")}</FormLabel>
               <FormControl>
                 <Input {...field} value={field.value ?? ""} />
               </FormControl>
@@ -174,7 +181,9 @@ export default function UserForm(props: UserFormProps) {
           render={({ field }) => (
             <FormItem>
               <FormLabel>
-                {props.isEdit ? "New password (optional)" : "Password"}
+                {props.isEdit
+                  ? t("userForm.newPasswordLabel")
+                  : t("fields.password")}
               </FormLabel>
               <FormControl>
                 <Input type="password" {...field} value={field.value ?? ""} />
@@ -189,7 +198,7 @@ export default function UserForm(props: UserFormProps) {
           name="full_name"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Full name</FormLabel>
+              <FormLabel>{t("fields.fullName")}</FormLabel>
               <FormControl>
                 <Input {...field} value={field.value ?? ""} />
               </FormControl>
@@ -203,17 +212,17 @@ export default function UserForm(props: UserFormProps) {
           name="rank"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Rank</FormLabel>
+              <FormLabel>{t("fields.rank")}</FormLabel>
               <Select onValueChange={field.onChange} value={field.value ?? ""}>
                 <FormControl>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select rank" />
+                    <SelectValue placeholder={t("userForm.selectRankPlaceholder")} />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
                   {MILITARY_RANKS.map((rank) => (
                     <SelectItem key={rank} value={rank}>
-                      {rank}
+                      {translateRank(t, rank)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -228,7 +237,7 @@ export default function UserForm(props: UserFormProps) {
           name="unit"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Unit</FormLabel>
+              <FormLabel>{t("fields.unit")}</FormLabel>
               <FormControl>
                 <Input {...field} value={field.value ?? ""} />
               </FormControl>
@@ -242,7 +251,7 @@ export default function UserForm(props: UserFormProps) {
           name="callsign"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Call sign</FormLabel>
+              <FormLabel>{t("userForm.callsignLabel")}</FormLabel>
               <FormControl>
                 <Input {...field} value={field.value ?? ""} />
               </FormControl>
@@ -256,17 +265,17 @@ export default function UserForm(props: UserFormProps) {
           name="clearance_level"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Clearance level</FormLabel>
+              <FormLabel>{t("userForm.clearanceLevelLabel")}</FormLabel>
               <Select onValueChange={field.onChange} value={field.value ?? ""}>
                 <FormControl>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select level" />
+                    <SelectValue placeholder={t("userForm.selectClearancePlaceholder")} />
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
                   {CLEARANCE_LEVELS.map((level) => (
                     <SelectItem key={level} value={level}>
-                      {level}
+                      {translateClearance(t, level)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -284,12 +293,12 @@ export default function UserForm(props: UserFormProps) {
 
             return (
               <FormItem>
-                <FormLabel>Permissions</FormLabel>
+                <FormLabel>{t("fields.permissions")}</FormLabel>
                 <div className="space-y-3 rounded-md border p-3">
                   {PERMISSION_GROUPS.map((group) => (
-                    <div key={group.label}>
+                    <div key={group.labelKey}>
                       <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        {group.label}
+                        {t(group.labelKey)}
                       </p>
                       <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
                         {group.perms.map((perm) => {
@@ -311,7 +320,7 @@ export default function UserForm(props: UserFormProps) {
                                   field.onChange(next);
                                 }}
                               />
-                              {PERMISSION_LABELS[perm]}
+                              {t(PERMISSION_LABEL_KEYS[perm])}
                             </label>
                           );
                         })}
@@ -330,7 +339,7 @@ export default function UserForm(props: UserFormProps) {
           name="is_active"
           render={({ field }) => (
             <FormItem className="flex items-center justify-between rounded-md border p-3">
-              <FormLabel className="mb-0">Active</FormLabel>
+              <FormLabel className="mb-0">{t("common.active")}</FormLabel>
               <FormControl>
                 <Switch
                   checked={field.value}
@@ -345,12 +354,12 @@ export default function UserForm(props: UserFormProps) {
           {props.isPending ? (
             <>
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              {props.isEdit ? "Saving..." : "Creating..."}
+              {props.isEdit ? t("common.saving") : t("common.creating")}
             </>
           ) : props.isEdit ? (
-            "Save changes"
+            t("userForm.saveChanges")
           ) : (
-            "Create user"
+            t("userForm.createUser")
           )}
         </Button>
       </form>

--- a/src/components/pages/users.tsx
+++ b/src/components/pages/users.tsx
@@ -44,6 +44,7 @@ import {
   PermissionDots,
   PermissionDotsHint,
 } from "@/components/pages/permission-dots";
+import { useLanguage, translateRank, translateClearance } from "@/lib/i18n";
 
 function clearanceBadgeVariant(level: string) {
   switch (level) {
@@ -62,6 +63,7 @@ function clearanceBadgeVariant(level: string) {
 export default function UsersPage() {
   const { user: currentUser } = useAuth();
   const { toast } = useToast();
+  const { t } = useLanguage();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editUser, setEditUser] = useState<SafeUser | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<SafeUser | null>(null);
@@ -83,12 +85,12 @@ export default function UsersPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/users"] });
       setDialogOpen(false);
-      toast({ title: "User created" });
+      toast({ title: t("users.createdToast") });
     },
     onError: (error: Error) => {
       toast({
         variant: "destructive",
-        title: "Error",
+        title: t("common.error"),
         description: error.message,
       });
     },
@@ -104,12 +106,12 @@ export default function UsersPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/users"] });
       setEditUser(null);
-      toast({ title: "Changes saved" });
+      toast({ title: t("users.savedToast") });
     },
     onError: (error: Error) => {
       toast({
         variant: "destructive",
-        title: "Error",
+        title: t("common.error"),
         description: error.message,
       });
     },
@@ -122,12 +124,12 @@ export default function UsersPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/users"] });
       setDeleteTarget(null);
-      toast({ title: "User deleted" });
+      toast({ title: t("users.deletedToast") });
     },
     onError: (error: Error) => {
       toast({
         variant: "destructive",
-        title: "Error",
+        title: t("common.error"),
         description: error.message,
       });
     },
@@ -143,10 +145,10 @@ export default function UsersPage() {
             className="text-xl font-semibold tracking-tight"
             data-testid="text-page-title"
           >
-            Users
+            {t("users.title")}
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Manage accounts and clearances
+            {t("users.subtitle")}
           </p>
         </div>
         <Button
@@ -155,16 +157,16 @@ export default function UsersPage() {
           data-testid="button-add-user"
         >
           <UserPlus className="mr-2 h-4 w-4" />
-          Add
+          {t("common.add")}
         </Button>
       </div>
 
       <div className="grid grid-cols-3 gap-3">
         {[
-          { label: "Total", value: users.length },
-          { label: "Active", value: activeCount },
-        ].map(({ label, value }) => (
-          <Card key={label}>
+          { id: "total", label: t("users.totalLabel"), value: users.length },
+          { id: "active", label: t("users.activeLabel"), value: activeCount },
+        ].map(({ id, label, value }) => (
+          <Card key={id}>
             <CardContent className="p-4">
               <p className="text-xs text-muted-foreground">{label}</p>
               <p className="text-2xl font-semibold tabular-nums">{value}</p>
@@ -184,25 +186,25 @@ export default function UsersPage() {
           ) : isError ? (
             <div className="flex items-center justify-center py-16">
               <div className="text-sm text-destructive">
-                {getErrorMessage(error, "Failed to load users")}
+                {getErrorMessage(error, t("users.loadError"))}
               </div>
             </div>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Full name</TableHead>
-                  <TableHead>Rank</TableHead>
-                  <TableHead>Unit</TableHead>
-                  <TableHead>Callsign</TableHead>
-                  <TableHead>Clearance</TableHead>
+                  <TableHead>{t("users.fullNameHeader")}</TableHead>
+                  <TableHead>{t("fields.rank")}</TableHead>
+                  <TableHead>{t("fields.unit")}</TableHead>
+                  <TableHead>{t("users.callsignHeader")}</TableHead>
+                  <TableHead>{t("users.clearanceHeader")}</TableHead>
                   <TableHead>
                     <span className="inline-flex items-center gap-1.5">
-                      Permissions
+                      {t("fields.permissions")}
                       <PermissionDotsHint />
                     </span>
                   </TableHead>
-                  <TableHead>Status</TableHead>
+                  <TableHead>{t("fields.status")}</TableHead>
                   <TableHead className="w-[80px]" />
                 </TableRow>
               </TableHeader>
@@ -215,14 +217,14 @@ export default function UsersPage() {
                         @{u.username}
                       </p>
                     </TableCell>
-                    <TableCell className="text-sm">{u.rank}</TableCell>
+                    <TableCell className="text-sm">{translateRank(t, u.rank)}</TableCell>
                     <TableCell className="text-sm">{u.unit}</TableCell>
                     <TableCell className="text-sm text-muted-foreground">
                       {u.callsign || "—"}
                     </TableCell>
                     <TableCell>
                       <Badge variant={clearanceBadgeVariant(u.clearance_level)}>
-                        {u.clearance_level}
+                        {translateClearance(t, u.clearance_level)}
                       </Badge>
                     </TableCell>
                     <TableCell>
@@ -230,7 +232,7 @@ export default function UsersPage() {
                     </TableCell>
                     <TableCell>
                       <Badge variant={u.is_active ? "default" : "secondary"}>
-                        {u.is_active ? "Active" : "Inactive"}
+                        {u.is_active ? t("common.active") : t("common.inactive")}
                       </Badge>
                     </TableCell>
                     <TableCell>
@@ -268,8 +270,10 @@ export default function UsersPage() {
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>New user</DialogTitle>
-            <DialogDescription>Create a new user account</DialogDescription>
+            <DialogTitle>{t("users.newUserDialogTitle")}</DialogTitle>
+            <DialogDescription>
+              {t("users.newUserDialogDescription")}
+            </DialogDescription>
           </DialogHeader>
           <UserForm
             onSubmit={(data) => createMutation.mutate(data)}
@@ -284,8 +288,12 @@ export default function UsersPage() {
       >
         <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Edit: {editUser?.full_name}</DialogTitle>
-            <DialogDescription>Update user account details</DialogDescription>
+            <DialogTitle>
+              {t("users.editDialogTitle", { name: editUser?.full_name ?? "" })}
+            </DialogTitle>
+            <DialogDescription>
+              {t("users.editDialogDescription")}
+            </DialogDescription>
           </DialogHeader>
           {editUser && (
             <UserForm
@@ -319,21 +327,23 @@ export default function UsersPage() {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete user?</AlertDialogTitle>
+            <AlertDialogTitle>{t("users.deleteDialogTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete {deleteTarget?.full_name} (@
-              {deleteTarget?.username})? This action cannot be undone.
+              {t("users.deleteDialogDescription", {
+                name: deleteTarget?.full_name ?? "",
+                username: deleteTarget?.username ?? "",
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() =>
                 deleteTarget && deleteMutation.mutate(deleteTarget.id)
               }
               data-testid="button-confirm-delete"
             >
-              Delete
+              {t("common.delete")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -5,13 +5,16 @@ import { queryClient } from "@/lib/queryClient";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
+import { LanguageProvider } from "@/lib/i18n";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <AuthProvider>{children}</AuthProvider>
+        <LanguageProvider>
+          <AuthProvider>{children}</AuthProvider>
+        </LanguageProvider>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -14,6 +14,7 @@ import {
 
 import { cn } from "@/lib/utils";
 import { Label } from "@/components/ui/label";
+import { useLanguage, type TranslationKey } from "@/lib/i18n";
 
 const Form = FormProvider;
 
@@ -148,7 +149,9 @@ const FormMessage = React.forwardRef<
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField();
-  const body = error ? String(error?.message ?? "") : children;
+  const { t } = useLanguage();
+  const raw = error ? String(error?.message ?? "") : undefined;
+  const body = raw ? t(raw as TranslationKey) : children;
 
   if (!body) {
     return null;

--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -6,6 +6,7 @@ import { apiRequest, queryClient, getQueryFn } from "@/lib/queryClient";
 import type { SafeUser } from "@/lib/userTypes";
 import type { LoginInput } from "@/lib/schema";
 import { useToast } from "@/hooks/use-toast";
+import { useLanguage } from "@/lib/i18n";
 
 interface AuthContextType {
   user: SafeUser | null;
@@ -18,6 +19,7 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const { toast } = useToast();
+  const { t } = useLanguage();
 
   const { data: user, isLoading } = useQuery<SafeUser | null>({
     queryKey: ["/api/auth/me"],
@@ -38,9 +40,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     onError: (error: Error) => {
       toast({
         variant: "destructive",
-        title: "Login Error",
+        title: t("auth.loginErrorTitle"),
         description: error.message.includes("401")
-          ? "Incorrect login or password"
+          ? t("auth.incorrectCredentials")
           : error.message,
       });
     },
@@ -57,7 +59,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     onError: (error: Error) => {
       toast({
         variant: "destructive",
-        title: "Exit error",
+        title: t("auth.logoutErrorTitle"),
         description: error.message,
       });
     },

--- a/src/lib/i18n/enumLabels.ts
+++ b/src/lib/i18n/enumLabels.ts
@@ -1,0 +1,44 @@
+import { MILITARY_RANKS, CLEARANCE_LEVELS } from "@/lib/schema";
+import type { Translate, TranslationKey } from "./translate";
+
+export const RANK_LABEL_KEYS: Record<(typeof MILITARY_RANKS)[number], TranslationKey> = {
+  Private: "ranks.private",
+  "Senior Private": "ranks.seniorPrivate",
+  "Junior Sergeant": "ranks.juniorSergeant",
+  Sergeant: "ranks.sergeant",
+  "Senior Sergeant": "ranks.seniorSergeant",
+  "Chief Sergeant": "ranks.chiefSergeant",
+  "Staff Sergeant": "ranks.staffSergeant",
+  "Master Sergeant": "ranks.masterSergeant",
+  "Senior Master Sergeant": "ranks.seniorMasterSergeant",
+  "Chief Master Sergeant": "ranks.chiefMasterSergeant",
+  "Junior Lieutenant": "ranks.juniorLieutenant",
+  Lieutenant: "ranks.lieutenant",
+  "Senior Lieutenant": "ranks.seniorLieutenant",
+  Captain: "ranks.captain",
+  Major: "ranks.major",
+  "Lieutenant Colonel": "ranks.lieutenantColonel",
+  Colonel: "ranks.colonel",
+  "Brigadier General": "ranks.brigadierGeneral",
+  "Major General": "ranks.majorGeneral",
+  "Lieutenant General": "ranks.lieutenantGeneral",
+  General: "ranks.general",
+};
+
+export const CLEARANCE_LABEL_KEYS: Record<(typeof CLEARANCE_LEVELS)[number], TranslationKey> = {
+  "No clearance": "clearanceLevels.none",
+  "For official use only": "clearanceLevels.officialUseOnly",
+  Secret: "clearanceLevels.secret",
+  "Top secret": "clearanceLevels.topSecret",
+  "Special importance": "clearanceLevels.specialImportance",
+};
+
+export function translateRank(t: Translate, rank: string): string {
+  const key = RANK_LABEL_KEYS[rank as (typeof MILITARY_RANKS)[number]];
+  return key ? t(key) : rank;
+}
+
+export function translateClearance(t: Translate, level: string): string {
+  const key = CLEARANCE_LABEL_KEYS[level as (typeof CLEARANCE_LEVELS)[number]];
+  return key ? t(key) : level;
+}

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,0 +1,9 @@
+export { LOCALES, DEFAULT_LOCALE, makeTranslate } from "./translate";
+export type { Locale, Translate, TranslationKey } from "./translate";
+export { LanguageProvider, useLanguage } from "./language-provider";
+export {
+  RANK_LABEL_KEYS,
+  CLEARANCE_LABEL_KEYS,
+  translateRank,
+  translateClearance,
+} from "./enumLabels";

--- a/src/lib/i18n/language-provider.tsx
+++ b/src/lib/i18n/language-provider.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { LOCALES, DEFAULT_LOCALE, makeTranslate, type Locale, type Translate } from "./translate";
+
+const STORAGE_KEY = "stockpulse:language";
+
+interface LanguageContextType {
+  language: Locale;
+  setLanguage: (locale: Locale) => void;
+  t: Translate;
+}
+
+const LanguageContext = createContext<LanguageContextType | null>(null);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Locale>(DEFAULT_LOCALE);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && (LOCALES as string[]).includes(stored)) {
+      setLanguage(stored as Locale);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = language;
+    window.localStorage.setItem(STORAGE_KEY, language);
+  }, [language]);
+
+  const t = useMemo(() => makeTranslate(language), [language]);
+  const value = useMemo(
+    () => ({ language, setLanguage, t }),
+    [language, t],
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const ctx = useContext(LanguageContext);
+  if (!ctx) throw new Error("useLanguage must be used within LanguageProvider");
+  return ctx;
+}

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -1,0 +1,303 @@
+{
+  "common": {
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "saving": "Wird gespeichert...",
+    "create": "Erstellen",
+    "creating": "Wird erstellt...",
+    "delete": "Löschen",
+    "deleting": "Wird gelöscht...",
+    "remove": "Entfernen",
+    "removing": "Wird entfernt...",
+    "add": "Hinzufügen",
+    "adding": "Wird hinzugefügt...",
+    "loading": "Wird geladen...",
+    "loadingProducts": "Produkte werden geladen...",
+    "noProductsFound": "Keine Produkte gefunden",
+    "active": "Aktiv",
+    "inactive": "Inaktiv",
+    "error": "Fehler",
+    "accessDenied": "Zugriff verweigert",
+    "actionsHeader": "Aktionen"
+  },
+  "fields": {
+    "fullName": "Vollständiger Name",
+    "username": "Benutzername",
+    "password": "Passwort",
+    "rank": "Dienstgrad",
+    "unit": "Einheit",
+    "sku": "Artikelnummer",
+    "category": "Kategorie",
+    "quantity": "Menge",
+    "permissions": "Berechtigungen",
+    "status": "Status"
+  },
+  "nav": {
+    "dashboard": "Übersicht",
+    "products": "Produkte",
+    "locations": "Standorte",
+    "users": "Benutzer",
+    "auditLogs": "Prüfprotokoll"
+  },
+  "appShell": {
+    "logoAlt": "StockPulse-Logo",
+    "openNavMenu": "Navigationsmenü öffnen",
+    "navMenuTitle": "Navigationsmenü",
+    "lightTheme": "Helles Design",
+    "darkTheme": "Dunkles Design",
+    "logout": "Abmelden",
+    "defaultUserBadge": "Benutzer"
+  },
+  "auth": {
+    "loginErrorTitle": "Anmeldefehler",
+    "incorrectCredentials": "Falscher Benutzername oder falsches Passwort",
+    "logoutErrorTitle": "Fehler beim Abmelden"
+  },
+  "login": {
+    "subtitle": "Lagerverwaltungssystem",
+    "cardHeading": "Systemanmeldung",
+    "usernamePlaceholder": "Benutzername eingeben",
+    "passwordPlaceholder": "Passwort eingeben",
+    "signingIn": "Anmeldung läuft…",
+    "signIn": "Anmelden",
+    "footerNote": "Der Zugang wird vom Systemadministrator erteilt"
+  },
+  "dashboard": {
+    "title": "Übersicht",
+    "subtitle": "Überblick über Ihren Lagerbestand",
+    "loadError": "Übersichtsdaten konnten nicht geladen werden",
+    "totalProducts": "Produkte gesamt",
+    "totalValue": "Gesamtwert",
+    "lowStock": "Niedriger Bestand",
+    "outOfStock": "Nicht vorrätig",
+    "categories": "Kategorien",
+    "lowStockAlerts": "Warnungen bei niedrigem Bestand",
+    "allWellStocked": "Alle Produkte sind ausreichend vorrätig",
+    "noProductsOutOfStock": "Keine Produkte sind nicht vorrätig",
+    "outOfStockBadge": "Nicht vorrätig",
+    "leftSuffix": "{{qty}} übrig"
+  },
+  "permissionDots": {
+    "logs": "Protokoll",
+    "noAccess": "Kein Zugriff",
+    "canView": "Ansehen",
+    "canEdit": "Bearbeiten",
+    "hintPrefix": "Reihenfolge der Punkte: {{list}}",
+    "hintAriaLabel": "Reihenfolge der Berechtigungspunkte erklären"
+  },
+  "logs": {
+    "title": "Prüfprotokoll",
+    "subtitle": "Verlauf der Änderungen an Systemobjekten und Benutzeraktionen.",
+    "refresh": "Aktualisieren",
+    "fetchError": "Prüfprotokoll konnte nicht geladen werden"
+  },
+  "logsFilters": {
+    "searchPlaceholder": "Tabelle, Datensatz-ID, Korrelations-ID suchen...",
+    "allTables": "Alle Tabellen",
+    "allActions": "Alle Aktionen",
+    "apply": "Anwenden",
+    "reset": "Zurücksetzen"
+  },
+  "logsTable": {
+    "loading": "Prüfprotokoll wird geladen...",
+    "empty": "Keine Protokolleinträge gefunden.",
+    "entityHeader": "Entität",
+    "actionHeader": "Aktion",
+    "actorHeader": "Ausführende Person",
+    "correlationIdHeader": "Korrelations-ID",
+    "createdAtHeader": "Erstellt am",
+    "noRecordId": "Keine Datensatz-ID",
+    "system": "System",
+    "collapseDetails": "Protokolldetails einklappen",
+    "expandDetails": "Protokolldetails ausklappen",
+    "oldValues": "Alte Werte",
+    "noPreviousValues": "Keine vorherigen Werte",
+    "changes": "Änderungen",
+    "newValues": "Neue Werte",
+    "noNewValues": "Keine neuen Werte",
+    "noChanges": "Keine Änderungen",
+    "noData": "Keine Daten",
+    "old": "Alt",
+    "new": "Neu"
+  },
+  "products": {
+    "title": "Produkte",
+    "itemsCount": {
+      "one": "{{count}} Artikel auf Lager",
+      "other": "{{count}} Artikel auf Lager"
+    },
+    "addProduct": "Produkt hinzufügen",
+    "deletedToastTitle": "Produkt gelöscht",
+    "deletedToastDescription": "Das Produkt wurde aus dem Lagerbestand entfernt.",
+    "deleteForbidden": "Sie haben keine Berechtigung, Produkte zu löschen.",
+    "deleteFailed": "Das Produkt konnte nicht gelöscht werden."
+  },
+  "productsFilters": {
+    "searchPlaceholder": "Suche nach Name, Artikelnummer oder Beschreibung...",
+    "allCategories": "Alle Kategorien"
+  },
+  "productsTable": {
+    "loading": "Produkte werden geladen...",
+    "forbidden": "Sie haben keine Berechtigung, Produkte anzuzeigen.",
+    "loadError": "Produkte konnten nicht geladen werden.",
+    "empty": "Keine Produkte gefunden",
+    "clearFilters": "Filter zurücksetzen",
+    "nameHeader": "Name",
+    "qtyHeader": "Menge",
+    "priceHeader": "Preis",
+    "outOfStock": "Nicht vorrätig",
+    "lowStock": "Niedriger Bestand",
+    "inStock": "Vorrätig"
+  },
+  "productsDeleteDialog": {
+    "title": "Produkt löschen",
+    "confirmMessage": "Sind Sie sicher, dass Sie \"{{name}}\" löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "productForm": {
+    "editTitle": "Produkt bearbeiten",
+    "editSubtitle": "Aktualisieren Sie die Produktdaten unten",
+    "addSubtitle": "Geben Sie die Produktdaten unten ein",
+    "nameLabel": "Produktname",
+    "namePlaceholder": "z. B. Kabellose Maus",
+    "skuPlaceholder": "z. B. WM-001",
+    "categoryPlaceholder": "z. B. Elektronik",
+    "priceLabel": "Preis ($)",
+    "lowStockLabel": "Warnschwelle für niedrigen Bestand",
+    "descriptionLabel": "Beschreibung",
+    "descriptionPlaceholder": "Optionale Produktbeschreibung...",
+    "updating": "Wird aktualisiert...",
+    "updateProduct": "Produkt aktualisieren",
+    "createProduct": "Produkt erstellen",
+    "updatedToastTitle": "Produkt aktualisiert",
+    "createdToastTitle": "Produkt erstellt",
+    "updatedToastDescription": "Das Produkt wurde erfolgreich aktualisiert.",
+    "createdToastDescription": "Das Produkt wurde dem Lagerbestand hinzugefügt.",
+    "forbidden": "Sie haben keine Berechtigung, Produkte zu verwalten.",
+    "skuConflict": "Ein Produkt mit dieser Artikelnummer existiert bereits."
+  },
+  "users": {
+    "title": "Benutzer",
+    "subtitle": "Konten und Freigabestufen verwalten",
+    "totalLabel": "Gesamt",
+    "activeLabel": "Aktiv",
+    "loadError": "Benutzer konnten nicht geladen werden",
+    "fullNameHeader": "Vollständiger Name",
+    "callsignHeader": "Rufzeichen",
+    "clearanceHeader": "Freigabe",
+    "newUserDialogTitle": "Neuer Benutzer",
+    "newUserDialogDescription": "Neues Benutzerkonto erstellen",
+    "editDialogTitle": "Bearbeiten: {{name}}",
+    "editDialogDescription": "Benutzerkontodaten aktualisieren",
+    "createdToast": "Benutzer erstellt",
+    "savedToast": "Änderungen gespeichert",
+    "deletedToast": "Benutzer gelöscht",
+    "deleteDialogTitle": "Benutzer löschen?",
+    "deleteDialogDescription": "Sind Sie sicher, dass Sie {{name}} (@{{username}}) löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden."
+  },
+  "userForm": {
+    "newPasswordLabel": "Neues Passwort (optional)",
+    "callsignLabel": "Rufzeichen",
+    "clearanceLevelLabel": "Freigabestufe",
+    "selectRankPlaceholder": "Dienstgrad wählen",
+    "selectClearancePlaceholder": "Stufe wählen",
+    "readGroup": "Lesen",
+    "writeGroup": "Schreiben",
+    "deleteGroup": "Löschen",
+    "debugLabel": "Diagnose",
+    "saveChanges": "Änderungen speichern",
+    "createUser": "Benutzer erstellen"
+  },
+  "locations": {
+    "title": "Standorte",
+    "subtitle": "Wählen Sie ein Produkt, um dessen Lagerstandorte zu verwalten",
+    "searchPlaceholder": "Produkte durchsuchen...",
+    "loadErrorFallback": "Produkte konnten nicht geladen werden",
+    "clearSearch": "Suche zurücksetzen",
+    "productHeader": "Produkt"
+  },
+  "locationForm": {
+    "forbidden": "Sie haben keine Berechtigung, Standorte zu verwalten.",
+    "alreadyLinked": "Dieser Standort ist bereits mit dem Produkt verknüpft.",
+    "backTitle": "Standorte: {{name}}",
+    "metaLine": "Artikelnummer: {{sku}} · Gesamtmenge: {{quantity}}",
+    "noLinkedLocations": "Keine verknüpften Standorte",
+    "linkedLocationsCount": {
+      "one": "{{count}} Standort",
+      "other": "{{count}} Standorte"
+    },
+    "addLocation": "Standort hinzufügen",
+    "locationAddedToast": "Standort hinzugefügt",
+    "quantityUpdatedToast": "Menge aktualisiert",
+    "locationRemovedToast": "Standort entfernt"
+  },
+  "locationSearch": {
+    "placeholder": "Bezeichnung eingeben... (R001C007L10)",
+    "noResults": "Keine Standorte gefunden"
+  },
+  "locationEntriesTable": {
+    "empty": "Dieses Produkt hat noch keine verknüpften Standorte",
+    "locationHeader": "Standort",
+    "quantityHeader": "Menge"
+  },
+  "locationAddDialog": {
+    "locationLabel": "Standort"
+  },
+  "locationDeleteDialog": {
+    "title": "Standort entfernen?",
+    "confirmMessagePart1": "Die Verknüpfung zwischen diesem Produkt und dem Standort {{label}} wird entfernt.",
+    "unitsReturn": {
+      "one": "{{count}} Einheit wird dem nicht zugewiesenen Bestand zurückgegeben.",
+      "other": "{{count}} Einheiten werden dem nicht zugewiesenen Bestand zurückgegeben."
+    }
+  },
+  "locationAllocationBanner": {
+    "allocatedLabel": "Zugewiesen:",
+    "balanced": "Ausgeglichen",
+    "unallocated": "Nicht zugewiesen: +{{delta}}",
+    "exceeded": "Überschritten: {{delta}}"
+  },
+  "validation": {
+    "nameRequired": "Name ist erforderlich",
+    "skuRequired": "Artikelnummer ist erforderlich",
+    "categoryRequired": "Kategorie ist erforderlich",
+    "levelRange": "Ebene muss 0, 10, 20, 30, 40, 50 oder 60 sein",
+    "invalidProductId": "Ungültige Produkt-ID",
+    "invalidLocationId": "Ungültige Standort-ID",
+    "quantityMin": "Menge muss 0 oder mehr sein",
+    "usernameMin": "Mindestens 3 Zeichen",
+    "passwordMin": "Mindestens 6 Zeichen",
+    "required": "Erforderlich",
+    "usernameRequired": "Benutzername ist erforderlich",
+    "passwordRequired": "Passwort ist erforderlich"
+  },
+  "ranks": {
+    "private": "Schütze",
+    "seniorPrivate": "Gefreiter",
+    "juniorSergeant": "Obergefreiter",
+    "sergeant": "Hauptgefreiter",
+    "seniorSergeant": "Stabsgefreiter",
+    "chiefSergeant": "Oberstabsgefreiter",
+    "staffSergeant": "Unteroffizier",
+    "masterSergeant": "Stabsunteroffizier",
+    "seniorMasterSergeant": "Feldwebel",
+    "chiefMasterSergeant": "Oberfeldwebel",
+    "juniorLieutenant": "Fähnrich",
+    "lieutenant": "Leutnant",
+    "seniorLieutenant": "Oberleutnant",
+    "captain": "Hauptmann",
+    "major": "Major",
+    "lieutenantColonel": "Oberstleutnant",
+    "colonel": "Oberst",
+    "brigadierGeneral": "Brigadegeneral",
+    "majorGeneral": "Generalmajor",
+    "lieutenantGeneral": "Generalleutnant",
+    "general": "General"
+  },
+  "clearanceLevels": {
+    "none": "Keine Freigabe",
+    "officialUseOnly": "Nur für den Dienstgebrauch",
+    "secret": "Geheim",
+    "topSecret": "Streng geheim",
+    "specialImportance": "Von besonderer Bedeutung"
+  }
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1,0 +1,303 @@
+{
+  "common": {
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving...",
+    "create": "Create",
+    "creating": "Creating...",
+    "delete": "Delete",
+    "deleting": "Deleting...",
+    "remove": "Remove",
+    "removing": "Removing...",
+    "add": "Add",
+    "adding": "Adding...",
+    "loading": "Loading...",
+    "loadingProducts": "Loading products...",
+    "noProductsFound": "No products found",
+    "active": "Active",
+    "inactive": "Inactive",
+    "error": "Error",
+    "accessDenied": "Access denied",
+    "actionsHeader": "Actions"
+  },
+  "fields": {
+    "fullName": "Full name",
+    "username": "Username",
+    "password": "Password",
+    "rank": "Rank",
+    "unit": "Unit",
+    "sku": "SKU",
+    "category": "Category",
+    "quantity": "Quantity",
+    "permissions": "Permissions",
+    "status": "Status"
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "products": "Products",
+    "locations": "Locations",
+    "users": "Users",
+    "auditLogs": "Audit Logs"
+  },
+  "appShell": {
+    "logoAlt": "StockPulse logo",
+    "openNavMenu": "Open navigation menu",
+    "navMenuTitle": "Navigation menu",
+    "lightTheme": "Light theme",
+    "darkTheme": "Dark theme",
+    "logout": "Logout",
+    "defaultUserBadge": "User"
+  },
+  "auth": {
+    "loginErrorTitle": "Login Error",
+    "incorrectCredentials": "Incorrect login or password",
+    "logoutErrorTitle": "Exit error"
+  },
+  "login": {
+    "subtitle": "Warehouse management system",
+    "cardHeading": "System login",
+    "usernamePlaceholder": "Enter username",
+    "passwordPlaceholder": "Enter password",
+    "signingIn": "Signing in…",
+    "signIn": "Sign in",
+    "footerNote": "Access is granted by the system administrator"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "subtitle": "Overview of your inventory status",
+    "loadError": "Failed to load dashboard data",
+    "totalProducts": "Total Products",
+    "totalValue": "Total Value",
+    "lowStock": "Low Stock",
+    "outOfStock": "Out of Stock",
+    "categories": "Categories",
+    "lowStockAlerts": "Low Stock Alerts",
+    "allWellStocked": "All products are well-stocked",
+    "noProductsOutOfStock": "No products are out of stock",
+    "outOfStockBadge": "Out of stock",
+    "leftSuffix": "{{qty}} left"
+  },
+  "permissionDots": {
+    "logs": "Logs",
+    "noAccess": "No access",
+    "canView": "Can view",
+    "canEdit": "Can edit",
+    "hintPrefix": "Dot order: {{list}}",
+    "hintAriaLabel": "Explain permission dot order"
+  },
+  "logs": {
+    "title": "Audit Logs",
+    "subtitle": "History of changes across system entities and user actions.",
+    "refresh": "Refresh",
+    "fetchError": "Failed to fetch audit logs"
+  },
+  "logsFilters": {
+    "searchPlaceholder": "Search table, record ID, correlation ID...",
+    "allTables": "All tables",
+    "allActions": "All actions",
+    "apply": "Apply",
+    "reset": "Reset"
+  },
+  "logsTable": {
+    "loading": "Loading audit logs...",
+    "empty": "No audit logs found.",
+    "entityHeader": "Entity",
+    "actionHeader": "Action",
+    "actorHeader": "Actor",
+    "correlationIdHeader": "Correlation ID",
+    "createdAtHeader": "Created At",
+    "noRecordId": "No record ID",
+    "system": "System",
+    "collapseDetails": "Collapse log details",
+    "expandDetails": "Expand log details",
+    "oldValues": "Old values",
+    "noPreviousValues": "No previous values",
+    "changes": "Changes",
+    "newValues": "New values",
+    "noNewValues": "No new values",
+    "noChanges": "No changes",
+    "noData": "No data",
+    "old": "Old",
+    "new": "New"
+  },
+  "products": {
+    "title": "Products",
+    "itemsCount": {
+      "one": "{{count}} item in inventory",
+      "other": "{{count}} items in inventory"
+    },
+    "addProduct": "Add Product",
+    "deletedToastTitle": "Product deleted",
+    "deletedToastDescription": "The product has been removed from inventory.",
+    "deleteForbidden": "You do not have permission to delete products.",
+    "deleteFailed": "Failed to delete the product."
+  },
+  "productsFilters": {
+    "searchPlaceholder": "Search by name, SKU, or description...",
+    "allCategories": "All Categories"
+  },
+  "productsTable": {
+    "loading": "Loading products...",
+    "forbidden": "You do not have permission to view products.",
+    "loadError": "Failed to fetch products.",
+    "empty": "No products found",
+    "clearFilters": "Clear filters",
+    "nameHeader": "Name",
+    "qtyHeader": "Qty",
+    "priceHeader": "Price",
+    "outOfStock": "Out of stock",
+    "lowStock": "Low stock",
+    "inStock": "In stock"
+  },
+  "productsDeleteDialog": {
+    "title": "Delete Product",
+    "confirmMessage": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone."
+  },
+  "productForm": {
+    "editTitle": "Edit Product",
+    "editSubtitle": "Update the product details below",
+    "addSubtitle": "Fill in the product details below",
+    "nameLabel": "Product Name",
+    "namePlaceholder": "e.g. Wireless Mouse",
+    "skuPlaceholder": "e.g. WM-001",
+    "categoryPlaceholder": "e.g. Electronics",
+    "priceLabel": "Price ($)",
+    "lowStockLabel": "Low Stock Alert",
+    "descriptionLabel": "Description",
+    "descriptionPlaceholder": "Optional product description...",
+    "updating": "Updating...",
+    "updateProduct": "Update Product",
+    "createProduct": "Create Product",
+    "updatedToastTitle": "Product updated",
+    "createdToastTitle": "Product created",
+    "updatedToastDescription": "The product has been updated successfully.",
+    "createdToastDescription": "The product has been added to inventory.",
+    "forbidden": "You do not have permission to manage products.",
+    "skuConflict": "A product with this SKU already exists."
+  },
+  "users": {
+    "title": "Users",
+    "subtitle": "Manage accounts and clearances",
+    "totalLabel": "Total",
+    "activeLabel": "Active",
+    "loadError": "Failed to load users",
+    "fullNameHeader": "Full name",
+    "callsignHeader": "Callsign",
+    "clearanceHeader": "Clearance",
+    "newUserDialogTitle": "New user",
+    "newUserDialogDescription": "Create a new user account",
+    "editDialogTitle": "Edit: {{name}}",
+    "editDialogDescription": "Update user account details",
+    "createdToast": "User created",
+    "savedToast": "Changes saved",
+    "deletedToast": "User deleted",
+    "deleteDialogTitle": "Delete user?",
+    "deleteDialogDescription": "Are you sure you want to delete {{name}} (@{{username}})? This action cannot be undone."
+  },
+  "userForm": {
+    "newPasswordLabel": "New password (optional)",
+    "callsignLabel": "Call sign",
+    "clearanceLevelLabel": "Clearance level",
+    "selectRankPlaceholder": "Select rank",
+    "selectClearancePlaceholder": "Select level",
+    "readGroup": "Read",
+    "writeGroup": "Write",
+    "deleteGroup": "Delete",
+    "debugLabel": "Debug",
+    "saveChanges": "Save changes",
+    "createUser": "Create user"
+  },
+  "locations": {
+    "title": "Locations",
+    "subtitle": "Select a product to manage its warehouse locations",
+    "searchPlaceholder": "Search products...",
+    "loadErrorFallback": "Failed to load products",
+    "clearSearch": "Clear search",
+    "productHeader": "Product"
+  },
+  "locationForm": {
+    "forbidden": "You do not have permission to manage locations.",
+    "alreadyLinked": "This location is already linked to the product.",
+    "backTitle": "Locations: {{name}}",
+    "metaLine": "SKU: {{sku}} · Total quantity: {{quantity}}",
+    "noLinkedLocations": "No linked locations",
+    "linkedLocationsCount": {
+      "one": "{{count}} location",
+      "other": "{{count}} locations"
+    },
+    "addLocation": "Add location",
+    "locationAddedToast": "Location added",
+    "quantityUpdatedToast": "Quantity updated",
+    "locationRemovedToast": "Location removed"
+  },
+  "locationSearch": {
+    "placeholder": "Enter label... (R001C007L10)",
+    "noResults": "No locations found"
+  },
+  "locationEntriesTable": {
+    "empty": "This product has no linked locations yet",
+    "locationHeader": "Location",
+    "quantityHeader": "Quantity"
+  },
+  "locationAddDialog": {
+    "locationLabel": "Location"
+  },
+  "locationDeleteDialog": {
+    "title": "Remove location?",
+    "confirmMessagePart1": "The link between this product and location {{label}} will be removed.",
+    "unitsReturn": {
+      "one": "{{count}} unit will return to the unallocated balance.",
+      "other": "{{count}} units will return to the unallocated balance."
+    }
+  },
+  "locationAllocationBanner": {
+    "allocatedLabel": "Allocated:",
+    "balanced": "Balanced",
+    "unallocated": "Unallocated: +{{delta}}",
+    "exceeded": "Exceeded: {{delta}}"
+  },
+  "validation": {
+    "nameRequired": "Name is required",
+    "skuRequired": "SKU is required",
+    "categoryRequired": "Category is required",
+    "levelRange": "Level must be 0, 10, 20, 30, 40, 50 or 60",
+    "invalidProductId": "Invalid product ID",
+    "invalidLocationId": "Invalid location ID",
+    "quantityMin": "Quantity must be 0 or more",
+    "usernameMin": "Min 3 characters",
+    "passwordMin": "Min 6 characters",
+    "required": "Required",
+    "usernameRequired": "Username is required",
+    "passwordRequired": "Password is required"
+  },
+  "ranks": {
+    "private": "Private",
+    "seniorPrivate": "Senior Private",
+    "juniorSergeant": "Junior Sergeant",
+    "sergeant": "Sergeant",
+    "seniorSergeant": "Senior Sergeant",
+    "chiefSergeant": "Chief Sergeant",
+    "staffSergeant": "Staff Sergeant",
+    "masterSergeant": "Master Sergeant",
+    "seniorMasterSergeant": "Senior Master Sergeant",
+    "chiefMasterSergeant": "Chief Master Sergeant",
+    "juniorLieutenant": "Junior Lieutenant",
+    "lieutenant": "Lieutenant",
+    "seniorLieutenant": "Senior Lieutenant",
+    "captain": "Captain",
+    "major": "Major",
+    "lieutenantColonel": "Lieutenant Colonel",
+    "colonel": "Colonel",
+    "brigadierGeneral": "Brigadier General",
+    "majorGeneral": "Major General",
+    "lieutenantGeneral": "Lieutenant General",
+    "general": "General"
+  },
+  "clearanceLevels": {
+    "none": "No clearance",
+    "officialUseOnly": "For official use only",
+    "secret": "Secret",
+    "topSecret": "Top secret",
+    "specialImportance": "Special importance"
+  }
+}

--- a/src/lib/i18n/locales/hr.json
+++ b/src/lib/i18n/locales/hr.json
@@ -1,0 +1,306 @@
+{
+  "common": {
+    "cancel": "Odustani",
+    "save": "Spremi",
+    "saving": "Spremanje...",
+    "create": "Stvori",
+    "creating": "Stvaranje...",
+    "delete": "Izbriši",
+    "deleting": "Brisanje...",
+    "remove": "Ukloni",
+    "removing": "Uklanjanje...",
+    "add": "Dodaj",
+    "adding": "Dodavanje...",
+    "loading": "Učitavanje...",
+    "loadingProducts": "Učitavanje proizvoda...",
+    "noProductsFound": "Proizvodi nisu pronađeni",
+    "active": "Aktivan",
+    "inactive": "Neaktivan",
+    "error": "Greška",
+    "accessDenied": "Pristup odbijen",
+    "actionsHeader": "Radnje"
+  },
+  "fields": {
+    "fullName": "Ime i prezime",
+    "username": "Korisničko ime",
+    "password": "Lozinka",
+    "rank": "Čin",
+    "unit": "Jedinica",
+    "sku": "Šifra",
+    "category": "Kategorija",
+    "quantity": "Količina",
+    "permissions": "Dozvole",
+    "status": "Status"
+  },
+  "nav": {
+    "dashboard": "Nadzorna ploča",
+    "products": "Proizvodi",
+    "locations": "Lokacije",
+    "users": "Korisnici",
+    "auditLogs": "Zapisnik revizije"
+  },
+  "appShell": {
+    "logoAlt": "StockPulse logotip",
+    "openNavMenu": "Otvori izbornik navigacije",
+    "navMenuTitle": "Izbornik navigacije",
+    "lightTheme": "Svijetla tema",
+    "darkTheme": "Tamna tema",
+    "logout": "Odjava",
+    "defaultUserBadge": "Korisnik"
+  },
+  "auth": {
+    "loginErrorTitle": "Greška prijave",
+    "incorrectCredentials": "Neispravno korisničko ime ili lozinka",
+    "logoutErrorTitle": "Greška odjave"
+  },
+  "login": {
+    "subtitle": "Sustav za upravljanje skladištem",
+    "cardHeading": "Prijava u sustav",
+    "usernamePlaceholder": "Unesite korisničko ime",
+    "passwordPlaceholder": "Unesite lozinku",
+    "signingIn": "Prijava…",
+    "signIn": "Prijavi se",
+    "footerNote": "Pristup odobrava administrator sustava"
+  },
+  "dashboard": {
+    "title": "Nadzorna ploča",
+    "subtitle": "Pregled stanja vašeg skladišta",
+    "loadError": "Učitavanje podataka nadzorne ploče nije uspjelo",
+    "totalProducts": "Ukupno proizvoda",
+    "totalValue": "Ukupna vrijednost",
+    "lowStock": "Niska zaliha",
+    "outOfStock": "Nema na zalihi",
+    "categories": "Kategorije",
+    "lowStockAlerts": "Upozorenja o niskoj zalihi",
+    "allWellStocked": "Svi proizvodi su dobro zalihe",
+    "noProductsOutOfStock": "Nema proizvoda kojih nema na zalihi",
+    "outOfStockBadge": "Nema na zalihi",
+    "leftSuffix": "preostalo: {{qty}}"
+  },
+  "permissionDots": {
+    "logs": "Zapisnik",
+    "noAccess": "Bez pristupa",
+    "canView": "Pregled",
+    "canEdit": "Uređivanje",
+    "hintPrefix": "Redoslijed točaka: {{list}}",
+    "hintAriaLabel": "Objasni redoslijed točaka dozvola"
+  },
+  "logs": {
+    "title": "Zapisnik revizije",
+    "subtitle": "Povijest promjena sustavskih entiteta i radnji korisnika.",
+    "refresh": "Osvježi",
+    "fetchError": "Učitavanje zapisnika revizije nije uspjelo"
+  },
+  "logsFilters": {
+    "searchPlaceholder": "Pretraži tablicu, ID zapisa, ID korelacije...",
+    "allTables": "Sve tablice",
+    "allActions": "Sve radnje",
+    "apply": "Primijeni",
+    "reset": "Poništi"
+  },
+  "logsTable": {
+    "loading": "Učitavanje zapisnika revizije...",
+    "empty": "Zapisnici revizije nisu pronađeni.",
+    "entityHeader": "Entitet",
+    "actionHeader": "Radnja",
+    "actorHeader": "Izvršitelj",
+    "correlationIdHeader": "ID korelacije",
+    "createdAtHeader": "Stvoreno",
+    "noRecordId": "Nema ID-a zapisa",
+    "system": "Sustav",
+    "collapseDetails": "Sažmi detalje zapisa",
+    "expandDetails": "Proširi detalje zapisa",
+    "oldValues": "Prijašnje vrijednosti",
+    "noPreviousValues": "Nema prijašnjih vrijednosti",
+    "changes": "Promjene",
+    "newValues": "Nove vrijednosti",
+    "noNewValues": "Nema novih vrijednosti",
+    "noChanges": "Nema promjena",
+    "noData": "Nema podataka",
+    "old": "Prije",
+    "new": "Poslije"
+  },
+  "products": {
+    "title": "Proizvodi",
+    "itemsCount": {
+      "one": "{{count}} proizvod na skladištu",
+      "few": "{{count}} proizvoda na skladištu",
+      "other": "{{count}} proizvoda na skladištu"
+    },
+    "addProduct": "Dodaj proizvod",
+    "deletedToastTitle": "Proizvod izbrisan",
+    "deletedToastDescription": "Proizvod je uklonjen iz zalihe.",
+    "deleteForbidden": "Nemate dozvolu za brisanje proizvoda.",
+    "deleteFailed": "Brisanje proizvoda nije uspjelo."
+  },
+  "productsFilters": {
+    "searchPlaceholder": "Pretraži po nazivu, šifri ili opisu...",
+    "allCategories": "Sve kategorije"
+  },
+  "productsTable": {
+    "loading": "Učitavanje proizvoda...",
+    "forbidden": "Nemate dozvolu za pregled proizvoda.",
+    "loadError": "Učitavanje proizvoda nije uspjelo.",
+    "empty": "Proizvodi nisu pronađeni",
+    "clearFilters": "Očisti filtre",
+    "nameHeader": "Naziv",
+    "qtyHeader": "Kol.",
+    "priceHeader": "Cijena",
+    "outOfStock": "Nema na zalihi",
+    "lowStock": "Niska zaliha",
+    "inStock": "Na zalihi"
+  },
+  "productsDeleteDialog": {
+    "title": "Izbriši proizvod",
+    "confirmMessage": "Jeste li sigurni da želite izbrisati \"{{name}}\"? Ova se radnja ne može poništiti."
+  },
+  "productForm": {
+    "editTitle": "Uredi proizvod",
+    "editSubtitle": "Ažurirajte podatke o proizvodu ispod",
+    "addSubtitle": "Ispunite podatke o proizvodu ispod",
+    "nameLabel": "Naziv proizvoda",
+    "namePlaceholder": "npr. Bežični miš",
+    "skuPlaceholder": "npr. WM-001",
+    "categoryPlaceholder": "npr. Elektronika",
+    "priceLabel": "Cijena ($)",
+    "lowStockLabel": "Upozorenje o niskoj zalihi",
+    "descriptionLabel": "Opis",
+    "descriptionPlaceholder": "Neobavezan opis proizvoda...",
+    "updating": "Ažuriranje...",
+    "updateProduct": "Ažuriraj proizvod",
+    "createProduct": "Stvori proizvod",
+    "updatedToastTitle": "Proizvod ažuriran",
+    "createdToastTitle": "Proizvod stvoren",
+    "updatedToastDescription": "Proizvod je uspješno ažuriran.",
+    "createdToastDescription": "Proizvod je dodan na zalihu.",
+    "forbidden": "Nemate dozvolu za upravljanje proizvodima.",
+    "skuConflict": "Proizvod s ovom šifrom već postoji."
+  },
+  "users": {
+    "title": "Korisnici",
+    "subtitle": "Upravljanje računima i razinama dopuštenja",
+    "totalLabel": "Ukupno",
+    "activeLabel": "Aktivni",
+    "loadError": "Učitavanje korisnika nije uspjelo",
+    "fullNameHeader": "Ime i prezime",
+    "callsignHeader": "Pozivni znak",
+    "clearanceHeader": "Dopuštenje",
+    "newUserDialogTitle": "Novi korisnik",
+    "newUserDialogDescription": "Stvori novi korisnički račun",
+    "editDialogTitle": "Uređivanje: {{name}}",
+    "editDialogDescription": "Ažuriraj podatke korisničkog računa",
+    "createdToast": "Korisnik stvoren",
+    "savedToast": "Promjene spremljene",
+    "deletedToast": "Korisnik izbrisan",
+    "deleteDialogTitle": "Izbrisati korisnika?",
+    "deleteDialogDescription": "Jeste li sigurni da želite izbrisati {{name}} (@{{username}})? Ova se radnja ne može poništiti."
+  },
+  "userForm": {
+    "newPasswordLabel": "Nova lozinka (neobavezno)",
+    "callsignLabel": "Pozivni znak",
+    "clearanceLevelLabel": "Razina dopuštenja",
+    "selectRankPlaceholder": "Odaberite čin",
+    "selectClearancePlaceholder": "Odaberite razinu",
+    "readGroup": "Pregled",
+    "writeGroup": "Uređivanje",
+    "deleteGroup": "Brisanje",
+    "debugLabel": "Dijagnostika",
+    "saveChanges": "Spremi promjene",
+    "createUser": "Stvori korisnika"
+  },
+  "locations": {
+    "title": "Lokacije",
+    "subtitle": "Odaberite proizvod za upravljanje njegovim skladišnim lokacijama",
+    "searchPlaceholder": "Pretraži proizvode...",
+    "loadErrorFallback": "Učitavanje proizvoda nije uspjelo",
+    "clearSearch": "Očisti pretragu",
+    "productHeader": "Proizvod"
+  },
+  "locationForm": {
+    "forbidden": "Nemate dozvolu za upravljanje lokacijama.",
+    "alreadyLinked": "Ova lokacija je već povezana s proizvodom.",
+    "backTitle": "Lokacije: {{name}}",
+    "metaLine": "Šifra: {{sku}} · Ukupna količina: {{quantity}}",
+    "noLinkedLocations": "Nema povezanih lokacija",
+    "linkedLocationsCount": {
+      "one": "{{count}} lokacija",
+      "few": "{{count}} lokacije",
+      "other": "{{count}} lokacija"
+    },
+    "addLocation": "Dodaj lokaciju",
+    "locationAddedToast": "Lokacija dodana",
+    "quantityUpdatedToast": "Količina ažurirana",
+    "locationRemovedToast": "Lokacija uklonjena"
+  },
+  "locationSearch": {
+    "placeholder": "Unesite oznaku... (R001C007L10)",
+    "noResults": "Lokacije nisu pronađene"
+  },
+  "locationEntriesTable": {
+    "empty": "Ovaj proizvod još nema povezanih lokacija",
+    "locationHeader": "Lokacija",
+    "quantityHeader": "Količina"
+  },
+  "locationAddDialog": {
+    "locationLabel": "Lokacija"
+  },
+  "locationDeleteDialog": {
+    "title": "Ukloniti lokaciju?",
+    "confirmMessagePart1": "Veza između ovog proizvoda i lokacije {{label}} bit će uklonjena.",
+    "unitsReturn": {
+      "one": "{{count}} jedinica će se vratiti u nerazvrstano stanje.",
+      "few": "{{count}} jedinice će se vratiti u nerazvrstano stanje.",
+      "other": "{{count}} jedinica će se vratiti u nerazvrstano stanje."
+    }
+  },
+  "locationAllocationBanner": {
+    "allocatedLabel": "Raspoređeno:",
+    "balanced": "Uravnoteženo",
+    "unallocated": "Neraspoređeno: +{{delta}}",
+    "exceeded": "Premašeno: {{delta}}"
+  },
+  "validation": {
+    "nameRequired": "Naziv je obavezan",
+    "skuRequired": "Šifra je obavezna",
+    "categoryRequired": "Kategorija je obavezna",
+    "levelRange": "Razina mora biti 0, 10, 20, 30, 40, 50 ili 60",
+    "invalidProductId": "Nevažeći ID proizvoda",
+    "invalidLocationId": "Nevažeći ID lokacije",
+    "quantityMin": "Količina mora biti 0 ili više",
+    "usernameMin": "Minimalno 3 znaka",
+    "passwordMin": "Minimalno 6 znakova",
+    "required": "Obavezno polje",
+    "usernameRequired": "Korisničko ime je obavezno",
+    "passwordRequired": "Lozinka je obavezna"
+  },
+  "ranks": {
+    "private": "Vojnik",
+    "seniorPrivate": "Razvodnik",
+    "juniorSergeant": "Mlađi vodnik",
+    "sergeant": "Vodnik",
+    "seniorSergeant": "Vodnik 1. klase",
+    "chiefSergeant": "Stožerni vodnik",
+    "staffSergeant": "Stožerni narednik",
+    "masterSergeant": "Narednik",
+    "seniorMasterSergeant": "Stariji narednik",
+    "chiefMasterSergeant": "Časnički namjesnik",
+    "juniorLieutenant": "Mlađi poručnik",
+    "lieutenant": "Poručnik",
+    "seniorLieutenant": "Nadporučnik",
+    "captain": "Satnik",
+    "major": "Bojnik",
+    "lieutenantColonel": "Podpukovnik",
+    "colonel": "Pukovnik",
+    "brigadierGeneral": "Brigadni general",
+    "majorGeneral": "General-bojnik",
+    "lieutenantGeneral": "General-pukovnik",
+    "general": "General"
+  },
+  "clearanceLevels": {
+    "none": "Bez dopusnice",
+    "officialUseOnly": "Samo za službenu uporabu",
+    "secret": "Povjerljivo",
+    "topSecret": "Strogo povjerljivo",
+    "specialImportance": "Od posebne važnosti"
+  }
+}

--- a/src/lib/i18n/locales/uk.json
+++ b/src/lib/i18n/locales/uk.json
@@ -1,0 +1,309 @@
+{
+  "common": {
+    "cancel": "Скасувати",
+    "save": "Зберегти",
+    "saving": "Збереження...",
+    "create": "Створити",
+    "creating": "Створення...",
+    "delete": "Видалити",
+    "deleting": "Видалення...",
+    "remove": "Прибрати",
+    "removing": "Прибирання...",
+    "add": "Додати",
+    "adding": "Додавання...",
+    "loading": "Завантаження...",
+    "loadingProducts": "Завантаження товарів...",
+    "noProductsFound": "Товарів не знайдено",
+    "active": "Активний",
+    "inactive": "Неактивний",
+    "error": "Помилка",
+    "accessDenied": "Доступ заборонено",
+    "actionsHeader": "Дії"
+  },
+  "fields": {
+    "fullName": "Повне ім'я",
+    "username": "Логін",
+    "password": "Пароль",
+    "rank": "Звання",
+    "unit": "Підрозділ",
+    "sku": "Артикул",
+    "category": "Категорія",
+    "quantity": "Кількість",
+    "permissions": "Права доступу",
+    "status": "Статус"
+  },
+  "nav": {
+    "dashboard": "Панель керування",
+    "products": "Товари",
+    "locations": "Локації",
+    "users": "Користувачі",
+    "auditLogs": "Журнал аудиту"
+  },
+  "appShell": {
+    "logoAlt": "Логотип StockPulse",
+    "openNavMenu": "Відкрити меню навігації",
+    "navMenuTitle": "Меню навігації",
+    "lightTheme": "Світла тема",
+    "darkTheme": "Темна тема",
+    "logout": "Вийти",
+    "defaultUserBadge": "Користувач"
+  },
+  "auth": {
+    "loginErrorTitle": "Помилка входу",
+    "incorrectCredentials": "Невірний логін або пароль",
+    "logoutErrorTitle": "Помилка виходу"
+  },
+  "login": {
+    "subtitle": "Система управління складом",
+    "cardHeading": "Вхід у систему",
+    "usernamePlaceholder": "Введіть логін",
+    "passwordPlaceholder": "Введіть пароль",
+    "signingIn": "Вхід…",
+    "signIn": "Увійти",
+    "footerNote": "Доступ надається адміністратором системи"
+  },
+  "dashboard": {
+    "title": "Панель керування",
+    "subtitle": "Огляд стану вашого складу",
+    "loadError": "Не вдалося завантажити дані панелі керування",
+    "totalProducts": "Усього товарів",
+    "totalValue": "Загальна вартість",
+    "lowStock": "Низький запас",
+    "outOfStock": "Немає в наявності",
+    "categories": "Категорії",
+    "lowStockAlerts": "Попередження про низький запас",
+    "allWellStocked": "Усі товари в достатній кількості",
+    "noProductsOutOfStock": "Немає товарів, яких бракує на складі",
+    "outOfStockBadge": "Немає в наявності",
+    "leftSuffix": "залишилось: {{qty}}"
+  },
+  "permissionDots": {
+    "logs": "Журнал",
+    "noAccess": "Немає доступу",
+    "canView": "Перегляд",
+    "canEdit": "Редагування",
+    "hintPrefix": "Порядок точок: {{list}}",
+    "hintAriaLabel": "Пояснення порядку точок дозволів"
+  },
+  "logs": {
+    "title": "Журнал аудиту",
+    "subtitle": "Історія змін системних сутностей та дій користувачів.",
+    "refresh": "Оновити",
+    "fetchError": "Не вдалося завантажити журнал аудиту"
+  },
+  "logsFilters": {
+    "searchPlaceholder": "Пошук за таблицею, ID запису, ID кореляції...",
+    "allTables": "Усі таблиці",
+    "allActions": "Усі дії",
+    "apply": "Застосувати",
+    "reset": "Скинути"
+  },
+  "logsTable": {
+    "loading": "Завантаження журналу аудиту...",
+    "empty": "Записів журналу аудиту не знайдено.",
+    "entityHeader": "Сутність",
+    "actionHeader": "Дія",
+    "actorHeader": "Виконавець",
+    "correlationIdHeader": "ID кореляції",
+    "createdAtHeader": "Створено",
+    "noRecordId": "Немає ID запису",
+    "system": "Система",
+    "collapseDetails": "Згорнути деталі запису",
+    "expandDetails": "Розгорнути деталі запису",
+    "oldValues": "Попередні значення",
+    "noPreviousValues": "Немає попередніх значень",
+    "changes": "Зміни",
+    "newValues": "Нові значення",
+    "noNewValues": "Немає нових значень",
+    "noChanges": "Без змін",
+    "noData": "Немає даних",
+    "old": "Було",
+    "new": "Стало"
+  },
+  "products": {
+    "title": "Товари",
+    "itemsCount": {
+      "one": "{{count}} товар на складі",
+      "few": "{{count}} товари на складі",
+      "many": "{{count}} товарів на складі",
+      "other": "{{count}} товару на складі"
+    },
+    "addProduct": "Додати товар",
+    "deletedToastTitle": "Товар видалено",
+    "deletedToastDescription": "Товар вилучено зі складу.",
+    "deleteForbidden": "У вас немає прав для видалення товарів.",
+    "deleteFailed": "Не вдалося видалити товар."
+  },
+  "productsFilters": {
+    "searchPlaceholder": "Пошук за назвою, артикулом або описом...",
+    "allCategories": "Усі категорії"
+  },
+  "productsTable": {
+    "loading": "Завантаження товарів...",
+    "forbidden": "У вас немає прав для перегляду товарів.",
+    "loadError": "Не вдалося завантажити товари.",
+    "empty": "Товарів не знайдено",
+    "clearFilters": "Очистити фільтри",
+    "nameHeader": "Назва",
+    "qtyHeader": "К-сть",
+    "priceHeader": "Ціна",
+    "outOfStock": "Немає в наявності",
+    "lowStock": "Мало на складі",
+    "inStock": "В наявності"
+  },
+  "productsDeleteDialog": {
+    "title": "Видалити товар",
+    "confirmMessage": "Ви впевнені, що хочете видалити «{{name}}»? Цю дію неможливо скасувати."
+  },
+  "productForm": {
+    "editTitle": "Редагувати товар",
+    "editSubtitle": "Оновіть дані товару нижче",
+    "addSubtitle": "Заповніть дані товару нижче",
+    "nameLabel": "Назва товару",
+    "namePlaceholder": "напр. Бездротова миша",
+    "skuPlaceholder": "напр. WM-001",
+    "categoryPlaceholder": "напр. Електроніка",
+    "priceLabel": "Ціна ($)",
+    "lowStockLabel": "Поріг низького запасу",
+    "descriptionLabel": "Опис",
+    "descriptionPlaceholder": "Необов'язковий опис товару...",
+    "updating": "Оновлення...",
+    "updateProduct": "Оновити товар",
+    "createProduct": "Створити товар",
+    "updatedToastTitle": "Товар оновлено",
+    "createdToastTitle": "Товар створено",
+    "updatedToastDescription": "Товар успішно оновлено.",
+    "createdToastDescription": "Товар додано на склад.",
+    "forbidden": "У вас немає прав для керування товарами.",
+    "skuConflict": "Товар із таким артикулом вже існує."
+  },
+  "users": {
+    "title": "Користувачі",
+    "subtitle": "Керування обліковими записами та рівнями допуску",
+    "totalLabel": "Усього",
+    "activeLabel": "Активні",
+    "loadError": "Не вдалося завантажити користувачів",
+    "fullNameHeader": "Повне ім'я",
+    "callsignHeader": "Позивний",
+    "clearanceHeader": "Допуск",
+    "newUserDialogTitle": "Новий користувач",
+    "newUserDialogDescription": "Створити новий обліковий запис",
+    "editDialogTitle": "Редагування: {{name}}",
+    "editDialogDescription": "Оновити дані облікового запису",
+    "createdToast": "Користувача створено",
+    "savedToast": "Зміни збережено",
+    "deletedToast": "Користувача видалено",
+    "deleteDialogTitle": "Видалити користувача?",
+    "deleteDialogDescription": "Ви впевнені, що хочете видалити {{name}} (@{{username}})? Цю дію неможливо скасувати."
+  },
+  "userForm": {
+    "newPasswordLabel": "Новий пароль (необов'язково)",
+    "callsignLabel": "Позивний",
+    "clearanceLevelLabel": "Рівень допуску",
+    "selectRankPlaceholder": "Оберіть звання",
+    "selectClearancePlaceholder": "Оберіть рівень",
+    "readGroup": "Перегляд",
+    "writeGroup": "Редагування",
+    "deleteGroup": "Видалення",
+    "debugLabel": "Діагностика",
+    "saveChanges": "Зберегти зміни",
+    "createUser": "Створити користувача"
+  },
+  "locations": {
+    "title": "Локації",
+    "subtitle": "Оберіть товар для керування його складськими локаціями",
+    "searchPlaceholder": "Пошук товарів...",
+    "loadErrorFallback": "Не вдалося завантажити товари",
+    "clearSearch": "Очистити пошук",
+    "productHeader": "Товар"
+  },
+  "locationForm": {
+    "forbidden": "У вас немає прав для керування локаціями.",
+    "alreadyLinked": "Ця локація вже пов'язана з товаром.",
+    "backTitle": "Локації: {{name}}",
+    "metaLine": "Артикул: {{sku}} · Загальна кількість: {{quantity}}",
+    "noLinkedLocations": "Немає пов'язаних локацій",
+    "linkedLocationsCount": {
+      "one": "{{count}} локація",
+      "few": "{{count}} локації",
+      "many": "{{count}} локацій",
+      "other": "{{count}} локації"
+    },
+    "addLocation": "Додати локацію",
+    "locationAddedToast": "Локацію додано",
+    "quantityUpdatedToast": "Кількість оновлено",
+    "locationRemovedToast": "Локацію видалено"
+  },
+  "locationSearch": {
+    "placeholder": "Введіть мітку... (R001C007L10)",
+    "noResults": "Локацій не знайдено"
+  },
+  "locationEntriesTable": {
+    "empty": "У цього товару ще немає пов'язаних локацій",
+    "locationHeader": "Локація",
+    "quantityHeader": "Кількість"
+  },
+  "locationAddDialog": {
+    "locationLabel": "Локація"
+  },
+  "locationDeleteDialog": {
+    "title": "Прибрати локацію?",
+    "confirmMessagePart1": "Зв'язок між цим товаром і локацією {{label}} буде видалено.",
+    "unitsReturn": {
+      "one": "{{count}} одиниця повернеться до нерозподіленого залишку.",
+      "few": "{{count}} одиниці повернуться до нерозподіленого залишку.",
+      "many": "{{count}} одиниць повернуться до нерозподіленого залишку.",
+      "other": "{{count}} одиниці повернеться до нерозподіленого залишку."
+    }
+  },
+  "locationAllocationBanner": {
+    "allocatedLabel": "Розподілено:",
+    "balanced": "Збалансовано",
+    "unallocated": "Нерозподілено: +{{delta}}",
+    "exceeded": "Перевищено: {{delta}}"
+  },
+  "validation": {
+    "nameRequired": "Назва обов'язкова",
+    "skuRequired": "Артикул обов'язковий",
+    "categoryRequired": "Категорія обов'язкова",
+    "levelRange": "Рівень має бути 0, 10, 20, 30, 40, 50 або 60",
+    "invalidProductId": "Недійсний ID товару",
+    "invalidLocationId": "Недійсний ID локації",
+    "quantityMin": "Кількість має бути 0 або більше",
+    "usernameMin": "Мінімум 3 символи",
+    "passwordMin": "Мінімум 6 символів",
+    "required": "Обов'язкове поле",
+    "usernameRequired": "Логін обов'язковий",
+    "passwordRequired": "Пароль обов'язковий"
+  },
+  "ranks": {
+    "private": "Рядовий",
+    "seniorPrivate": "Старший солдат",
+    "juniorSergeant": "Молодший сержант",
+    "sergeant": "Сержант",
+    "seniorSergeant": "Старший сержант",
+    "chiefSergeant": "Головний сержант",
+    "staffSergeant": "Штаб-сержант",
+    "masterSergeant": "Майстер-сержант",
+    "seniorMasterSergeant": "Старший майстер-сержант",
+    "chiefMasterSergeant": "Головний майстер-сержант",
+    "juniorLieutenant": "Молодший лейтенант",
+    "lieutenant": "Лейтенант",
+    "seniorLieutenant": "Старший лейтенант",
+    "captain": "Капітан",
+    "major": "Майор",
+    "lieutenantColonel": "Підполковник",
+    "colonel": "Полковник",
+    "brigadierGeneral": "Бригадний генерал",
+    "majorGeneral": "Генерал-майор",
+    "lieutenantGeneral": "Генерал-лейтенант",
+    "general": "Генерал"
+  },
+  "clearanceLevels": {
+    "none": "Без допуску",
+    "officialUseOnly": "Для службового користування",
+    "secret": "Таємно",
+    "topSecret": "Цілком таємно",
+    "specialImportance": "Особливої важливості"
+  }
+}

--- a/src/lib/i18n/translate.ts
+++ b/src/lib/i18n/translate.ts
@@ -1,0 +1,126 @@
+import en from "./locales/en.json";
+import uk from "./locales/uk.json";
+import hr from "./locales/hr.json";
+import de from "./locales/de.json";
+
+export type Locale = "en" | "uk" | "hr" | "de";
+export const LOCALES: Locale[] = ["en", "uk", "hr", "de"];
+export const DEFAULT_LOCALE: Locale = "uk";
+const FALLBACK_LOCALE: Locale = "en";
+
+const DICTIONARIES: Record<Locale, unknown> = { en, uk, hr, de };
+
+type Dictionary = typeof en;
+type Join<K extends string, P extends string> = P extends ""
+  ? K
+  : `${K}.${P}`;
+
+// A plural group leaf, e.g. { "one": "...", "other": "..." }.
+type PluralGroup = { one?: string; few?: string; many?: string; other: string };
+
+// Paths to plain string leaves only (excludes plural group objects).
+type DotPaths<T> = T extends string
+  ? ""
+  : {
+      [K in keyof T & string]: T[K] extends PluralGroup
+        ? never
+        : T[K] extends Record<string, unknown>
+          ? Join<K, DotPaths<T[K]>>
+          : K;
+    }[keyof T & string];
+export type TranslationKey = DotPaths<Dictionary>;
+
+// Paths to plural group objects only (the parent path passed to t.plural()).
+type PluralPaths<T> = T extends string
+  ? never
+  : {
+      [K in keyof T & string]: T[K] extends PluralGroup
+        ? K
+        : T[K] extends Record<string, unknown>
+          ? Join<K, PluralPaths<T[K]>>
+          : never;
+    }[keyof T & string];
+export type PluralTranslationKey = PluralPaths<Dictionary>;
+
+function getPath(dict: unknown, path: string): unknown {
+  return path
+    .split(".")
+    .reduce<unknown>(
+      (acc, part) =>
+        acc && typeof acc === "object" && part in (acc as Record<string, unknown>)
+          ? (acc as Record<string, unknown>)[part]
+          : undefined,
+      dict,
+    );
+}
+
+function interpolate(
+  tpl: string,
+  vars?: Record<string, string | number>,
+): string {
+  if (!vars) return tpl;
+  return tpl.replace(/\{\{(\w+)\}\}/g, (match, name: string) =>
+    name in vars ? String(vars[name]) : match,
+  );
+}
+
+export interface Translate {
+  (key: TranslationKey, vars?: Record<string, string | number>): string;
+  plural(
+    key: PluralTranslationKey,
+    count: number,
+    vars?: Record<string, string | number>,
+  ): string;
+}
+
+export function makeTranslate(locale: Locale): Translate {
+  const pluralRules = new Intl.PluralRules(locale);
+
+  const resolve = (key: string): string | undefined => {
+    const direct = getPath(DICTIONARIES[locale], key);
+    if (typeof direct === "string") return direct;
+
+    if (locale !== FALLBACK_LOCALE) {
+      const fallback = getPath(DICTIONARIES[FALLBACK_LOCALE], key);
+      if (typeof fallback === "string") {
+        if (process.env.NODE_ENV !== "production") {
+          console.warn(
+            `[i18n] Missing key "${key}" for locale "${locale}"; falling back to English.`,
+          );
+        }
+        return fallback;
+      }
+    }
+
+    return undefined;
+  };
+
+  const t = ((key: TranslationKey, vars?: Record<string, string | number>) => {
+    const tpl = resolve(key);
+    if (tpl === undefined) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[i18n] Unknown key "${key}".`);
+      }
+      return key;
+    }
+    return interpolate(tpl, vars);
+  }) as Translate;
+
+  t.plural = (
+    key: PluralTranslationKey,
+    count: number,
+    vars?: Record<string, string | number>,
+  ) => {
+    const category = pluralRules.select(count);
+    const tpl = resolve(`${key}.${category}`) ?? resolve(`${key}.other`);
+    if (tpl === undefined) {
+      if (process.env.NODE_ENV !== "production") {
+        console.warn(`[i18n] Missing plural key "${key}" (${category}).`);
+      }
+      return key;
+    }
+    return interpolate(tpl, { count, ...vars });
+  };
+
+  return t;
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -23,9 +23,9 @@ export interface Product {
 }
 
 export const insertProductSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  sku: z.string().min(1, "SKU is required"),
-  category: z.string().min(1, "Category is required"),
+  name: z.string().min(1, "validation.nameRequired"),
+  sku: z.string().min(1, "validation.skuRequired"),
+  category: z.string().min(1, "validation.categoryRequired"),
   quantity: z.number().int().min(0).default(0),
   price: z.number().min(0).default(0),
   low_stock_threshold: z.number().int().min(0).default(10),
@@ -50,7 +50,7 @@ export const insertLocationSchema = z.object({
     .number()
     .int()
     .refine((v) => [0, 10, 20, 30, 40, 50, 60].includes(v), {
-      message: "Level must be 0, 10, 20, 30, 40, 50 or 60",
+      message: "validation.levelRange",
     }),
 });
 
@@ -71,9 +71,9 @@ export interface ProductLocationView extends ProductLocation {
 }
 
 export const insertProductLocationSchema = z.object({
-  product_id: z.uuid({ error: "Invalid product ID" }),
-  location_id: z.uuid({ error: "Invalid location ID" }),
-  quantity: z.number().int().min(0, { error: "Quantity must be 0 or more" }),
+  product_id: z.uuid({ error: "validation.invalidProductId" }),
+  location_id: z.uuid({ error: "validation.invalidLocationId" }),
+  quantity: z.number().int().min(0, { error: "validation.quantityMin" }),
 });
 
 export type InsertProductLocation = z.infer<typeof insertProductLocationSchema>;
@@ -114,11 +114,11 @@ export const CLEARANCE_LEVELS = [
 
 // ── Users ─────────────────────────────────────────────
 export const insertUserSchema = z.object({
-  username: z.string().min(3, { error: "Min 3 characters" }).max(50),
-  password: z.string().min(6, { error: "Min 6 characters" }),
-  full_name: z.string().min(1, { error: "Required" }),
-  rank: z.string().min(1, { error: "Required" }),
-  unit: z.string().min(1, { error: "Required" }),
+  username: z.string().min(3, { error: "validation.usernameMin" }).max(50),
+  password: z.string().min(6, { error: "validation.passwordMin" }),
+  full_name: z.string().min(1, { error: "validation.required" }),
+  rank: z.string().min(1, { error: "validation.required" }),
+  unit: z.string().min(1, { error: "validation.required" }),
   callsign: z.string().nullable().optional(),
   clearance_level: z.string().default("No clearance"),
   permissions: z.array(permissionSchema).default([]),
@@ -127,7 +127,7 @@ export const insertUserSchema = z.object({
 
 const optionalPasswordSchema = z.preprocess(
   (value) => (value === "" ? undefined : value),
-  z.string().min(6, { error: "Min 6 characters" }).optional(),
+  z.string().min(6, { error: "validation.passwordMin" }).optional(),
 );
 
 export const updateUserSchema = insertUserSchema
@@ -141,8 +141,8 @@ export type InsertUser = z.infer<typeof insertUserSchema>;
 export type UpdateUser = z.infer<typeof updateUserSchema>;
 
 export const loginSchema = z.object({
-  username: z.string().min(1, "Username is required"),
-  password: z.string().min(1, "Password is required"),
+  username: z.string().min(1, "validation.usernameRequired"),
+  password: z.string().min(1, "validation.passwordRequired"),
 });
 
 export type LoginInput = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## Summary
- Extract all user-visible text into JSON locale files (`src/lib/i18n/locales/{en,uk,hr,de}.json`, 239 keys each) instead of hardcoded strings scattered across components
- Add a `LanguageProvider`/`useLanguage()` context that persists the selection to `localStorage`, sets `document.documentElement.lang`, and defaults to Ukrainian
- Add a language dropdown in the sidebar (native endonyms: English / Українська / Hrvatski / Deutsch)
- Add a small `translate.ts` engine with compile-time-checked translation keys (`TranslationKey`) via mapped/template-literal types, so referencing a non-existent key is a TypeScript error
- Add CLDR-correct pluralization via `Intl.PluralRules` (`t.plural(key, count, vars)`), covering Ukrainian's one/few/many/other and Croatian's one/few/other categories
- Wire military ranks and clearance levels through translation helpers (`translateRank`, `translateClearance`) while keeping the underlying `<SelectItem>` values as the original English canonical strings (no DB/wire format change)
- Route all zod validation messages through translation keys, with `FormMessage` auto-translating them app-wide with no per-form wiring
- Fix a latent bug found during this work: `locations.tsx` sorted names with `localeCompare(..., "uk", ...)` hardcoded regardless of the active UI language; now uses the current language

## Scope exclusions
- No changes to API/DB layer; only display text and validation messages are translated
- `location-delete-dialog.tsx` drops bold styling on the interpolated location label, since `{{label}}` interpolation is plain text and can't carry embedded JSX

## Verification
- `npx tsc --noEmit` clean
- Manually verified language switcher updates nav labels, form labels, validation messages, rank/clearance labels, and audit log text across all four locales
- Confirmed all locale JSON files have no missing keys relative to the English master (used as the TypeScript reference shape)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJf8EnPpTRCyb1V3uSSrfH)_